### PR TITLE
Components/buttons

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
     'import/prefer-default-export': 0,
     'consistent-return': 0,
     semi: 0,
+    'react/forbid-prop-types': 0,
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn'
   }

--- a/components/Onboarding/Configure/Ledger/Step1.jsx
+++ b/components/Onboarding/Configure/Ledger/Step1.jsx
@@ -62,13 +62,13 @@ export default () => {
         <Button
           title='Back'
           onClick={() => setWalletType(null)}
-          buttonStyle='secondary'
+          variant='secondary'
           mr={2}
         />
         <Button
           title='Yes, my Ledger device is connected.'
           onClick={setLedgerProvider}
-          buttonStyle='primary'
+          variant='primary'
           ml={2}
         />
       </Box>

--- a/components/Onboarding/Configure/Ledger/Step2.jsx
+++ b/components/Onboarding/Configure/Ledger/Step2.jsx
@@ -119,7 +119,7 @@ export default () => {
         <Button
           title='Back'
           onClick={() => setWalletType(null)}
-          buttonStyle='secondary'
+          variant='secondary'
           mr={2}
         />
         <Button
@@ -135,7 +135,7 @@ export default () => {
               dispatch(error(err))
             }
           }}
-          buttonStyle='primary'
+          variant='primary'
           ml={2}
         />
       </Box>

--- a/components/Shared/AccountCard/Error.jsx
+++ b/components/Shared/AccountCard/Error.jsx
@@ -27,12 +27,7 @@ const AccountError = ({ errorMsg, onTryAgain }) => (
       <Text margin={0}>{errorMsg}</Text>
     </Box>
     <Box display='flex'>
-      <Button
-        buttonStyle='tertiary'
-        title='Try again'
-        onClick={onTryAgain}
-        p={2}
-      />
+      <Button variant='tertiary' title='Try again' onClick={onTryAgain} p={2} />
     </Box>
   </Box>
 )

--- a/components/Shared/AccountCard/index.jsx
+++ b/components/Shared/AccountCard/index.jsx
@@ -54,14 +54,14 @@ const AccountCard = forwardRef(
         </Box>
         <Box display='flex'>
           <Button
-            buttonStyle='tertiary'
+            variant='tertiary'
             title='Switch'
             onClick={onAccountSwitch}
             p={2}
           />
           {isLedgerWallet && (
             <Button
-              buttonStyle='tertiary'
+              variant='tertiary'
               title='View on Ledger'
               onClick={onShowOnLedger}
               ml={2}

--- a/components/Shared/BalanceCard/index.jsx
+++ b/components/Shared/BalanceCard/index.jsx
@@ -28,14 +28,14 @@ const BalanceCard = forwardRef(
       </Box>
       <Box display='flex' justifyContent='space-between'>
         <Button
-          buttonStyle='secondary'
+          variant='secondary'
           title='Receive'
           disabled={disableButtons}
           onClick={onReceive}
           width={120}
         />
         <Button
-          buttonStyle='primary'
+          variant='primary'
           title='Send'
           disabled={disableButtons}
           onClick={onSend}

--- a/components/Shared/Button/BaseButton.js
+++ b/components/Shared/Button/BaseButton.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { space, layout, borderRadius, flexbox, variant } from 'styled-system'
+import { space, layout, borderRadius, flexbox } from 'styled-system'
 
 export default styled.button`
   variant {
@@ -18,6 +18,6 @@ export default styled.button`
   font-size: ${props => props.theme.fontSizes[2]}; 
   ${borderRadius} 
   ${space}
-    ${layout} 
-    ${flexbox};
+  ${layout} 
+  ${flexbox}
 `

--- a/components/Shared/Button/BaseButton.js
+++ b/components/Shared/Button/BaseButton.js
@@ -1,17 +1,20 @@
 import styled from 'styled-components'
-import { space, layout, borderRadius, flexbox } from 'styled-system'
+import { space, layout, borderRadius, flexbox, variant } from 'styled-system'
 
 export default styled.button`
+  variant {
+    scale: 'buttons';
+  }
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   background-color: ${props =>
     props.disabled
       ? props.theme.colors.status.inactive
-      : props.theme.colors.buttons[props.buttonStyle].background};
+      : props.theme.colors.buttons[props.variant].background};
   border-color: ${props =>
     props.disabled
       ? props.theme.colors.status.inactive
-      : props.theme.colors.buttons[props.buttonStyle].borderColor};
-  color: ${props => props.theme.colors.buttons[props.buttonStyle].color};
+      : props.theme.colors.buttons[props.variant].borderColor};
+  color: ${props => props.theme.colors.buttons[props.variant].color};
   font-size: ${props => props.theme.fontSizes[2]}; 
   ${borderRadius} 
   ${space}

--- a/components/Shared/Button/index.jsx
+++ b/components/Shared/Button/index.jsx
@@ -7,7 +7,6 @@ import theme from '../theme'
 const Button = forwardRef(({ disabled, onClick, title, ...props }, ref) => (
   <BaseButton
     variant={variant}
-    // buttonStyle={buttonStyle}
     p={3}
     fontSize={3}
     borderRadius={2}
@@ -22,7 +21,6 @@ const Button = forwardRef(({ disabled, onClick, title, ...props }, ref) => (
 
 Button.propTypes = {
   variant: oneOf(Object.keys(theme.buttons)),
-  // buttonStyle: oneOf(Object.keys(theme.colors.buttons)),
   onClick: func.isRequired,
   title: string.isRequired,
   disabled: bool
@@ -30,7 +28,6 @@ Button.propTypes = {
 
 Button.defaultProps = {
   variant: 'primary'
-  // buttonStyle: 'primary'
 }
 
 export default Button

--- a/components/Shared/Button/index.jsx
+++ b/components/Shared/Button/index.jsx
@@ -1,36 +1,36 @@
 import React, { forwardRef } from 'react'
+import { variant } from 'styled-system'
 import { func, bool, string, oneOf } from 'prop-types'
 import BaseButton from './BaseButton'
 import theme from '../theme'
 
-const Button = forwardRef(
-  ({ buttonStyle, disabled, onClick, title, ...props }, ref) => (
-    <BaseButton
-      buttonStyle={buttonStyle}
-      p={3}
-      fontSize={3}
-      borderRadius={2}
-      onClick={onClick}
-      disabled={disabled}
-      ref={ref}
-      {...props}
-    >
-      {title}
-    </BaseButton>
-  )
-)
+const Button = forwardRef(({ disabled, onClick, title, ...props }, ref) => (
+  <BaseButton
+    variant={variant}
+    // buttonStyle={buttonStyle}
+    p={3}
+    fontSize={3}
+    borderRadius={2}
+    onClick={onClick}
+    disabled={disabled}
+    ref={ref}
+    {...props}
+  >
+    {title}
+  </BaseButton>
+))
 
-const ButtonPropTypes = {
-  buttonStyle: oneOf(Object.keys(theme.colors.buttons)),
+Button.propTypes = {
+  variant: oneOf(Object.keys(theme.buttons)),
+  // buttonStyle: oneOf(Object.keys(theme.colors.buttons)),
   onClick: func.isRequired,
   title: string.isRequired,
   disabled: bool
 }
 
-Button.propTypes = ButtonPropTypes
-
 Button.defaultProps = {
-  buttonStyle: 'primary'
+  variant: 'primary'
+  // buttonStyle: 'primary'
 }
 
 export default Button

--- a/components/Shared/IconButtons/index.jsx
+++ b/components/Shared/IconButtons/index.jsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import styled from 'styled-components'
-import { func, string } from 'prop-types'
+import { func, object } from 'prop-types'
 import { layout, space, border } from 'styled-system'
 import { IconClose, IconCopyAccountAddress } from '../Icons'
 
@@ -28,8 +28,7 @@ const IconButton = forwardRef(({ onClick, Icon, ...props }, ref) => (
 
 const ButtonClosePropTypes = {
   onClick: func.isRequired,
-  buttonStyle: string,
-  Icon: string
+  Icon: object
 }
 
 IconButton.propTypes = ButtonClosePropTypes

--- a/components/Shared/theme.js
+++ b/components/Shared/theme.js
@@ -63,11 +63,6 @@ const colors = {
       background: baseColors.mono.transparent,
       borderColor: baseColors.purple.light,
       color: baseColors.purple.light
-    },
-    'transparent-dark': {
-      bg: 'black',
-      borderColor: 'black',
-      color: 'black'
     }
   },
   background: {
@@ -115,9 +110,29 @@ const colors = {
   }
 }
 
+const buttons = {
+  colors,
+  primary: {
+    color: colors.buttons.primary.color,
+    borderColor: colors.buttons.primary.color,
+    backgroundColor: colors.buttons.tertiary.background
+  },
+  secondary: {
+    background: colors.buttons.secondary.background,
+    borderColor: colors.buttons.secondary.color,
+    color: colors.buttons.secondary.color
+  },
+  tertiary: {
+    background: baseColors.mono.transparent,
+    borderColor: baseColors.purple.light,
+    color: baseColors.purple.light
+  }
+}
+
 // theme.js
 const theme = {
   colors,
+  buttons,
   fontSizes: ['0rem', '1rem', '1.125rem', '1.25rem', '1.5rem', '2rem', '3rem'],
   fontWeights: [0, 400, 600, 900],
   letterSpacings: [0, 1, 2, 4, 8],

--- a/components/Wallet/Send.js/ErrorCard.jsx
+++ b/components/Wallet/Send.js/ErrorCard.jsx
@@ -23,7 +23,7 @@ const ErrorCard = ({ error, reset }) => {
         <Button
           onClick={reset}
           title='Try Again'
-          buttonStyle='tertiary'
+          variant='tertiary'
           height='100%'
           css={`
             align-self: flex-end;

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -307,11 +307,7 @@ const Send = ({ setSending }) => {
               </Text>
             ) : (
               <>
-                <Button
-                  title='Cancel'
-                  buttonStyle='secondary'
-                  onClick={() => {}}
-                />
+                <Button title='Cancel' variant='secondary' onClick={() => {}} />
                 <Button
                   disabled={
                     !!(
@@ -327,7 +323,7 @@ const Send = ({ setSending }) => {
                   }
                   type='submit'
                   title='Next'
-                  buttonStyle='primary'
+                  variant='primary'
                   onClick={() => {}}
                 />
               </>


### PR DESCRIPTION
Replaces `buttonStyle` prop with styled-system's `variant` across all `Button` components.

## Theme.js
Adds new `button` object, currently with colors, but can be expanded to include padding, fontSize, etc. declarations

## BaseButton

Replaced `buttonStyles` with `variant` across cursor, background/border/color.

## Buttons updated
1. Primary & Secondary buttons in `Ledger onboarding`
1. Tertiary buttons in `AccountCard`
1. Send / Receive buttons `BalanceCard`
1. Back/Cancel and Next/Confirm in `FloatingButtons` in `Send` flow
1. Clear/Try Again button in `ErrorCard`
 