### PR TITLE
StepCard Stepper Color & Primary Button updates

### DIFF
--- a/components/Onboarding/Configure/Ledger/StepCard.jsx
+++ b/components/Onboarding/Configure/Ledger/StepCard.jsx
@@ -17,8 +17,8 @@ const StepCard = ({ step }) => {
         <Glyph acronym='Ld' />
         <Stepper
           textColor='text'
-          completedDotColor='green'
-          incompletedDotColor='silver'
+          completedDotColor='status.success.background'
+          incompletedDotColor='status.inactive'
           step={step}
           totalSteps={3}
           ml={4}

--- a/components/Shared/theme.js
+++ b/components/Shared/theme.js
@@ -17,7 +17,8 @@ const baseColors = {
   green: {
     primary: '#1AD08F',
     light: '#D2F5ED',
-    dark: '#007056'
+    dark: '#007056',
+    darker: '#08442F'
   },
   red: {
     light: '#FC6D6F',
@@ -52,7 +53,7 @@ const colors = {
     primary: {
       background: baseColors.green.primary,
       borderColor: baseColors.green.primary,
-      color: baseColors.mono.nearblack
+      color: baseColors.green.darker
     },
     secondary: {
       background: baseColors.mono.transparent,


### PR DESCRIPTION
Tiny PR.

## StepCard

Replaces `completedDotColor='green'` with `completedDotColor='status.success.background'` to match the rest of the app.

## Primary Button & Theme

Adds `Darker Green` color into `BaseColors` to reference inside of the `Primary Button` color object, replacing `nearblack`

