### PR TITLE
Fix/input bg

### DIFF
--- a/components/Shared/Input/BaseInput.js
+++ b/components/Shared/Input/BaseInput.js
@@ -6,20 +6,21 @@ export default styled.input`
   flex-grow: 1;
   padding-left: ${props => props.theme.space[2]}px;
   padding-right: ${props => props.theme.space[2]}px;
-  border: ${props => props.theme.borders[1]}
-  border-radius: ${props => props.theme.radii[1]}
+  border: ${props => props.theme.borders[1]};
+  border-radius: ${props => props.theme.radii[1]};
   transition: 0.2s ease-in-out;
   font-size: ${props => props.theme.fontSizes[2]};
   text-align: right;
   cursor: text;
-  background: ${props =>
-    props.disabled
-      ? props.theme.colors.status.inactive
-      : props.theme.colors.input.background.base};
+  background: ${props => props.theme.colors.input.background.base};
+  /* @jon - The below background change needs to be tied to a validation check on the user-submitted content. If valid, it will display a light green color, otherwise it will display red.
+  /* background: ${props =>
+    props.valid
+      ? props.theme.colors.input.background.valid
+      : props.theme.colors.input.background.invalid}; */
 
   &:hover {
-    background: ${props =>
-      !props.disabled && props.theme.colors.input.background.active};
+    cursor: ${props => (props.disabled ? 'not-allowed' : 'text')};
   }
 
   &:focus {
@@ -27,6 +28,7 @@ export default styled.input`
     outline: 0;
     background: ${props => props.theme.colors.input.background.active};
   }
+}
 
   ${color}
   ${space}

--- a/components/Shared/Input/BaseInput.js
+++ b/components/Shared/Input/BaseInput.js
@@ -13,11 +13,6 @@ export default styled.input`
   text-align: right;
   cursor: text;
   background: ${props => props.theme.colors.input.background.base};
-  /* @jon - The below background change needs to be tied to a validation check on the user-submitted content. If valid, it will display a light green color, otherwise it will display red.
-  /* background: ${props =>
-    props.valid
-      ? props.theme.colors.input.background.valid
-      : props.theme.colors.input.background.invalid}; */
 
   &:hover {
     cursor: ${props => (props.disabled ? 'not-allowed' : 'text')};

--- a/components/Shared/theme.js
+++ b/components/Shared/theme.js
@@ -90,7 +90,9 @@ const colors = {
   input: {
     background: {
       base: baseColors.blue.light,
-      active: baseColors.blue.mid
+      active: baseColors.blue.mid,
+      valid: baseColors.green.light,
+      invalid: baseColors.red.light
     },
     border: core.silver
   },


### PR DESCRIPTION
# Changes

## BaseInput

1. Removed the ternary operator that would change background based on the `disabled` flag.
1. Replaced it with a commented out ternary operator for a `valid` or `invalid` flag, tied to new colors added to the theme file.

## Theme
1. Added `colors.input.background.valid` and `colors.input.background.invalid` to enable conditional styling of background based on valid/invalid user input.

---

## Problem 🔴 

1. Chrome's default internal stylesheet imposes a background style on any `input` that allows `auto-complete`. This is why there was a difference between the `Address` and `Funds` inputs - because `Address` *allows* auto-complete, but `Funds` *does not*.

## Solution 🍏 

### The simple one
Set `auto-complete="off"` in the `<form>` element `line:194` inside `components/Wallet/Send.js/index.jsx`

### Bang your head against the wall:
https://stackoverflow.com/questions/2338102/override-browser-form-filling-and-input-highlighting-with-html-css


# To-Do

1. Attach `backgroundColor` to your `Address` validation check: `backgroundColor="input.background.valid` and `backgroundColor="input.background.invalid`

1. I believe we don't need to add this validation check to `Funds` as you already have the error display setup there. I just need to color it. 