### PR TITLE
Update Funds Input. Replace "IconApproximatelyEquals".

### DIFF
--- a/components/Shared/Input/Funds.jsx
+++ b/components/Shared/Input/Funds.jsx
@@ -5,7 +5,6 @@ import { FilecoinNumber, BigNumber } from '@openworklabs/filecoin-number'
 import Box from '../Box'
 import { RawNumberInput } from './Number'
 import { Text, Label } from '../Typography'
-import { IconApproximatelyEquals } from '../Icons/index'
 import { FILECOIN_NUMBER_PROP } from '../../../customPropTypes'
 
 const formatFilValue = number => {
@@ -171,7 +170,6 @@ const Funds = forwardRef(
           width='100%'
           maxWidth={11}
           textAlign='center'
-          borderRight={1}
           borderColor='input.border'
           bg={error && 'input.background.invalid'}
         >
@@ -179,12 +177,24 @@ const Funds = forwardRef(
         </Box>
         <Box display='inline-block' width='100%'>
           <Box position='relative' display='block' height='80px' width='100%'>
-            <IconApproximatelyEquals
+            <Box
               position='absolute'
               left='-24px'
-              bottom='-42px'
-              size={7}
-            />
+              bottom='-24px'
+              display='flex'
+              alignItems='center'
+              justifyContent='center'
+              backgroundColor='core.white'
+              border={1}
+              borderColor='input.border'
+              borderRadius={5}
+              size={6}
+              fontSize={5}
+              fontFamily='sansSerif'
+              paddingBottom='4px'
+            >
+              {'\u003D'}
+            </Box>
 
             <RawNumberInput
               onFocus={() => {


### PR DESCRIPTION
Closes #146 

# What?
1. Removes a `borderRight` declaration from the `Amount` container that was generating two borders (as `borderLeft` is invoked by the container of the `Funds` inputs).

2. Also replaces the `IconApproximatelyEquals` with a "pure HTML/markup" solution that also uses the unicode equals sign. This icon remains inside the `Icons` file in case we need/want to use it in the future.

The updated, rendered `SendCard` looks like:

![image](https://user-images.githubusercontent.com/6787950/75813386-af79c400-5d6e-11ea-8e1e-1273e4ef79a8.png)


