### PR TITLE
Add hover state to BaseButton

### DIFF
--- a/components/Shared/Button/BaseButton.js
+++ b/components/Shared/Button/BaseButton.js
@@ -19,7 +19,7 @@ export default styled.button`
   transition: 0.18s ease-in-out;
 
   &:hover {
-    opacity: 0.8;
+    opacity: ${props => (props.disabled ? '1' : '0.8')};
   }
   ${borderRadius} 
   ${space}

--- a/components/Shared/Button/BaseButton.js
+++ b/components/Shared/Button/BaseButton.js
@@ -16,6 +16,11 @@ export default styled.button`
       : props.theme.colors.buttons[props.variant].borderColor};
   color: ${props => props.theme.colors.buttons[props.variant].color};
   font-size: ${props => props.theme.fontSizes[2]}; 
+  transition: 0.18s ease-in-out;
+
+  &:hover {
+    opacity: 0.8;
+  }
   ${borderRadius} 
   ${space}
   ${layout} 


### PR DESCRIPTION
This adds a simple hover state that adjusts the opacity of non-disabled buttons to `0.8`