### PR TITLE
Init. Setting up SidebarLayout

### DIFF
--- a/components/Shared/Layout/SidebarLayout.jsx
+++ b/components/Shared/Layout/SidebarLayout.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 // Sidebar layout w/ implicit sizing & wrap, courtesy of https://every-layout.dev/layouts/sidebar/
 
 // Wrapper wraps the content and applies a negative margin onto "Gutter" - thus acting as a defacto gutter between the Sidebar and Content sections.
-const Wrapper = styled.div`
+export const Wrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     flex-grow: 999;
@@ -23,14 +23,14 @@ const Wrapper = styled.div`
   }
   `
 // Creates an implicit gutter between Sidebar and Content
-const Gutter = styled.div``
+export const Gutter = styled.div``
 
 // Sidebar grows to adopt the width of its children
-const Sidebar = styled.div`
+export const Sidebar = styled.div`
   flex-grow: 1;
 `
 // Content is a flexible container with no explicit width (hence basis=0) but which grows to consume all available space. It then wraps once its min-width is reached.
-const Content = styled.div`
+export const Content = styled.div`
   display: flex;
   flex-basis: 0;
   flex-grow: 999;
@@ -38,11 +38,3 @@ const Content = styled.div`
   padding-top: ${props => props.theme.sizes[4]}px;
   min-width: calc(55% - 1rem);
 `
-export const SidebarLayout = props => (
-  <Wrapper>
-    <Gutter>
-      <Sidebar>{props.children.sidebar}</Sidebar>
-      <Content>{props.children.content}</Content>
-    </Gutter>
-  </Wrapper>
-)

--- a/components/Shared/Layout/SidebarLayout.jsx
+++ b/components/Shared/Layout/SidebarLayout.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import styled from 'styled-components'
+
+// Sidebar layout w/ implicit sizing & wrap, courtesy of https://every-layout.dev/layouts/sidebar/
+
+// Wrapper wraps the content and applies a negative margin onto "Gutter" - thus acting as a defacto gutter between the Sidebar and Content sections.
+const Wrapper = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    flex-grow: 999;
+
+    > * {
+      display: flex;
+      flex-wrap: wrap;
+      flex-grow: 999;
+      margin: -0.5rem;
+    }
+
+    > * > * {
+      /* ↓ applies to both elements */
+      margin: 0.5rem;
+    }
+  }
+  `
+// Creates an implicit gutter between Sidebar and Content
+const Gutter = styled.div``
+
+// Sidebar grows to adopt the width of its children
+const Sidebar = styled.div`
+  flex-grow: 1;
+`
+// Content is a flexible container with no explicit width (hence basis=0) but which grows to consume all available space. It then wraps once its min-width is reached.
+const Content = styled.div`
+  display: flex;
+  flex-basis: 0;
+  flex-grow: 999;
+  justify-content: center;
+  padding-top: ${props => props.theme.sizes[4]}px;
+  min-width: calc(55% - 1rem);
+`
+export const SidebarLayout = props => (
+  <Wrapper>
+    <Gutter>
+      <Sidebar>{props.children.sidebar}</Sidebar>
+      <Content>{props.children.content}</Content>
+    </Gutter>
+  </Wrapper>
+)

--- a/components/Shared/index.js
+++ b/components/Shared/index.js
@@ -22,5 +22,8 @@ export * from './Menu'
 export * from './Icons'
 export * from './IconButtons'
 
+// layout
+export * from './Layout/SidebarLayout'
+
 // typography
 export * from './Typography'

--- a/components/Wallet/index.jsx
+++ b/components/Wallet/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { useRouter } from 'next/router'
+import { Wrapper, Gutter, Sidebar, Content } from '../Shared/'
 import {
   AccountCard,
   AccountError,
@@ -25,44 +26,6 @@ import {
 } from '../../utils/ledger/reportLedgerConfigError'
 import MsgConfirmer from '../../lib/confirm-message'
 import useUpToDateBalance from '../../lib/update-balance'
-
-// Sidebar layout w/ implicit sizing & wrap, courtesy of https://every-layout.dev/layouts/sidebar/
-
-// Wrapper wraps the content and applies a negative margin onto "Gutter" - thus acting as a defacto gutter between the Sidebar and Content sections.
-const Wrapper = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    flex-grow: 999;
-
-    > * {
-      display: flex;
-      flex-wrap: wrap;
-      flex-grow: 999;
-      margin: -0.5rem;
-    }
-
-    > * > * {
-      /* ↓ applies to both elements */
-      margin: 0.5rem;
-    }
-  }
-  `
-// Creates an implicit gutter between Sidebar and Content
-const Gutter = styled.div``
-
-// Sidebar grows to adopt the width of its children
-const Sidebar = styled.div`
-  flex-grow: 1;
-`
-// Content is a flexible container with no explicit width (hence basis=0) but which grows to consume all available space. It then wraps once its min-width is reached.
-const Content = styled.div`
-  display: flex;
-  flex-basis: 0;
-  flex-grow: 999;
-  justify-content: center;
-  padding-top: ${props => props.theme.sizes[4]}px;
-  min-width: calc(55% - 1rem);
-`
 
 const WalletView = ({ wallet }) => {
   useUpToDateBalance()


### PR DESCRIPTION
Closes #137 

The goal of this PR is to standardize any sidebar based page layouts by pulling out the layout constants inside of `components/Wallet/index.jsx` into their own file within `Layouts/SidebarLayout.jsx`

1. Sidebar layout components (`Wrapper`, `Gutter`, `Sidebar` & `Content`) have been moved to the `SidebarLayout` file.

2. These components have been re-imported into `components/Wallet/index.js`