### PR TITLE
Update AccountSwitcher screen

### DIFF
--- a/components/AccountSelector/index.jsx
+++ b/components/AccountSelector/index.jsx
@@ -185,12 +185,16 @@ const AccountSelector = () => {
                   display='flex'
                   flexDirection='column'
                   justifyContent='space-between'
-                  width={11}
-                  height={11}
+                  width='300px'
+                  height='300px'
                   borderRadius={2}
                   p={3}
                 >
                   <Title>Choose an account</Title>
+                  <Text>
+                    Choose which account on your Ledger device you want to
+                    access with Glif
+                  </Text>
                 </Card>
               )}
             </>

--- a/components/AccountSelector/index.jsx
+++ b/components/AccountSelector/index.jsx
@@ -191,10 +191,7 @@ const AccountSelector = () => {
                   p={3}
                 >
                   <Title>Choose an account</Title>
-                  <Text m={0}>
-                    Choose which account on your Ledger device you want to
-                    access with Glif
-                  </Text>
+                  <Text m={0}>Select a wallet to use with Glif.</Text>
                 </Card>
               )}
             </>

--- a/components/AccountSelector/index.jsx
+++ b/components/AccountSelector/index.jsx
@@ -191,7 +191,7 @@ const AccountSelector = () => {
                   p={3}
                 >
                   <Title>Choose an account</Title>
-                  <Text>
+                  <Text m={0}>
                     Choose which account on your Ledger device you want to
                     access with Glif
                   </Text>

--- a/components/Shared/AccountCardAlt/index.jsx
+++ b/components/Shared/AccountCardAlt/index.jsx
@@ -25,6 +25,9 @@ const AccountCardAlt = ({
         css={`
           transition: 0.2s ease-in-out;
           cursor: pointer;
+          &:hover {
+            background: ${selected && hsla(0, 0%, 90%, 1)};
+          }
         `}
         onClick={onClick}
         display='flex'

--- a/components/Shared/AccountCardAlt/index.jsx
+++ b/components/Shared/AccountCardAlt/index.jsx
@@ -17,7 +17,7 @@ const AccountCardAlt = ({
   return (
     <Box my={2} display='flex' flexDirection='column' {...props}>
       {selected && (
-        <Text my={1} width='100%' textAlign='right' color='core.primary'>
+        <Text my={1} width='100%' textAlign='left' color='core.primary'>
           CURRENT
         </Text>
       )}

--- a/components/Shared/AccountCardAlt/index.jsx
+++ b/components/Shared/AccountCardAlt/index.jsx
@@ -3,7 +3,7 @@ import { string, number, bool, func } from 'prop-types'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import Box from '../Box'
 import Glyph from '../Glyph'
-import { Text } from '../Typography'
+import { Text, Title } from '../Typography'
 import truncate from '../../../utils/truncateAddress'
 
 const AccountCardAlt = ({
@@ -17,24 +17,25 @@ const AccountCardAlt = ({
   return (
     <Box my={2} display='flex' flexDirection='column' {...props}>
       {selected && (
-        <Text my={1} color='core.primary'>
+        <Text my={1} width='100%' textAlign='right' color='core.primary'>
           CURRENT
         </Text>
       )}
       <Box
         css={`
+          transition: 0.2s ease-in-out;
           cursor: pointer;
         `}
         onClick={onClick}
         display='flex'
         flexDirection='row'
         justifyContent='space-between'
-        width={12}
+        width='100%'
         height={8}
         border={1}
         borderRadius={2}
         p={3}
-        bg={selected && 'card.account.background'}
+        bg={selected ? 'card.account.background' : 'colors.core.white'}
         color={selected ? 'card.account.color' : 'colors.core.black'}
         boxShadow={1}
       >
@@ -48,18 +49,18 @@ const AccountCardAlt = ({
             <Text fontSize={3} my={0}>
               Address
             </Text>
-            <Text my={0} fontSize={6}>
+            <Title fontSize={4} my={0}>
               {truncate(address)}
-            </Text>
+            </Title>
           </Box>
         </Box>
         <Box display='flex' flexDirection='column'>
           <Text fontSize={3} my={0}>
             Balance
           </Text>
-          <Text my={0} fontSize={6}>
+          <Title fontSize={4} my={0}>
             {balance}FIL
-          </Text>
+          </Title>
         </Box>
       </Box>
     </Box>

--- a/components/Shared/AccountCardAlt/index.jsx
+++ b/components/Shared/AccountCardAlt/index.jsx
@@ -26,7 +26,7 @@ const AccountCardAlt = ({
           transition: 0.2s ease-in-out;
           cursor: pointer;
           &:hover {
-            background: ${selected && hsla(0, 0%, 90%, 1)};
+            background: ${!selected && 'hsla(0, 0%, 90%, 1)'};
           }
         `}
         onClick={onClick}
@@ -38,7 +38,7 @@ const AccountCardAlt = ({
         border={1}
         borderRadius={2}
         p={3}
-        bg={selected ? 'card.account.background' : 'colors.core.white'}
+        bg={selected ? 'card.account.background' : 'hsla(0, 0%, 90%, 0)'}
         color={selected ? 'card.account.color' : 'colors.core.black'}
         boxShadow={1}
       >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6787950/76325632-4e01aa00-62c6-11ea-9651-a8d3e6c97de7.png)

1. Adds descriptive copy to 'Choose an Account' card.
1. Sets up `hover` state with background change for non-`selected` accounts
1. Removes arbitrary height declaration
1. Increases `AccountCardAlt` width to `100%`
1. Increases `fontSize` of account address & balance per Figma design.
1. `textAlign` set to `left` for "Current" text label.