### PR TITLE
Update theme box-shadow & ErrorCard color prop

### DIFF
--- a/components/Shared/AccountCard/Error.jsx
+++ b/components/Shared/AccountCard/Error.jsx
@@ -15,14 +15,15 @@ const AccountError = ({ errorMsg, onTryAgain }) => (
     borderRadius={2}
     p={3}
     bg='card.error.background'
+    color='card.error.foreground'
     boxShadow={1}
     mb={2}
   >
     <Box display='flex' alignItems='center' justifyContent='flex-start'>
-      <Glyph mr={3} color='card.account.color' acronym='Er' />
+      <Glyph mr={3} acronym='Er' />
       <Text>Error</Text>
     </Box>
-    <Box color='card.account.color'>
+    <Box>
       <Title>Ledger Device Problem</Title>
       <Text margin={0}>{errorMsg}</Text>
     </Box>

--- a/components/Shared/AccountCardAlt/index.jsx
+++ b/components/Shared/AccountCardAlt/index.jsx
@@ -36,7 +36,6 @@ const AccountCardAlt = ({
         p={3}
         bg={selected && 'card.account.background'}
         color={selected ? 'card.account.color' : 'colors.core.black'}
-        boxShadow={1}
       >
         <Box display='flex' alignItems='center' justifyContent='flex-start'>
           <Glyph

--- a/components/Shared/Box/index.js
+++ b/components/Shared/Box/index.js
@@ -4,6 +4,7 @@ import {
   border,
   layout,
   space,
+  shadow,
   flexbox,
   grid,
   position
@@ -21,4 +22,5 @@ export default styled.div`
   ${flexbox}
   ${typography}
   ${grid}
+  ${shadow}
 `

--- a/components/Shared/theme.js
+++ b/components/Shared/theme.js
@@ -201,7 +201,7 @@ const theme = {
   // Alex, Todo - Use SmoothShadow https://css-tricks.com/make-a-smooth-shadow-friend/
   shadows: [
     '0',
-    '0 0.9px 9px rgba(0, 0, 0, 0.017), 0 2.2px 18.6px rgba(0, 0, 0, 0.027),0 4.1px 29.7px rgba(0, 0, 0, 0.034),0 7.4px 45.2px rgba(0, 0, 0, 0.041),0 13.8px 73.1px rgba(0, 0, 0, 0.051), 0 33px 160px rgba(0, 0, 0, 0.07)'
+    '0 0.7px 2.2px -8px rgba(0, 0, 0, 0.18),0 1.7px 5.4px  rgba(0, 0, 0, 0.129),0 3.1px 10.1px rgba(0, 0, 0, 0.107),0 5.6px 18.1px rgba(0, 0, 0, 0.09),0 10.4px 33.8px rgba(0, 0, 0, 0.073),0 25px 81px rgba(0, 0, 0, 0.051)'
   ],
   opacity: {
     disabled: 0.4


### PR DESCRIPTION
This is a tiny thing that has been nagging at me for a couple of weeks.

Updates the theme's box-shadow and adds the `${shadow}` prop to `Box` so we can pass that theme prop to the `AccountCard` and its derivatives.

Looks like this now:

![image](https://user-images.githubusercontent.com/6787950/76340215-fa995700-62d9-11ea-8a71-226e2fef499a.png)

Also took the liberty to update the `ErrorCard` color to use its defined color props in the theme file.