### PR TITLE
Add margin to Content element of Sidebar Layout

### DIFF
--- a/components/Shared/Layout/SidebarLayout.jsx
+++ b/components/Shared/Layout/SidebarLayout.jsx
@@ -22,4 +22,5 @@ export const Content = styled.div`
   padding-top: ${props => props.theme.sizes[4]}px;
   margin: 0.5rem;
   min-width: 53%;
+  margin-bottom: 6rem;
 `

--- a/components/Shared/MessageHistoryTable/index.jsx
+++ b/components/Shared/MessageHistoryTable/index.jsx
@@ -16,7 +16,7 @@ const MessageHistoryTable = ({
   ...props
 }) => {
   return (
-    <Box {...props} maxWidth={16}>
+    <Box {...props} maxWidth={16} width='100%'>
       <Box display='flex' alignItems='center' justifyContent='flex-start'>
         <Glyph mr={3} color='core.primary' acronym='Tx' />
         <Text color='core.primary'>Transaction History</Text>


### PR DESCRIPTION
This just adds a `6rem` margin to the bottom, allowing users to scroll down far enough so that the FloatingContainer doesn't obscure their view of the SendCard, or any other elements on other pages.

Why is the `6rem` / 96px margin hardcoded instead of referencing the theme? Because we don't have a value for that exact amount in the theme - we only have 80px or 160px - one's too small the other too big and I'd rather not add to the size object in the theme file and have to update a bunch of components right now. 

But if you insist I should, I will 😎 