### PR TITLE
Add text styles, update BalanceCard

### DIFF
--- a/components/Shared/BalanceCard/index.jsx
+++ b/components/Shared/BalanceCard/index.jsx
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react'
 import { func, bool } from 'prop-types'
-import { BigNumber } from '@openworklabs/filecoin-number'
+// import { BigNumber } from '@openworklabs/filecoin-number'
 import Box from '../Box'
 import Button from '../Button'
-import { BigTitle, Title, Label } from '../Typography'
+import { HugeNumber, BigNumber, Title, Label } from '../Typography'
 import { FILECOIN_NUMBER_PROP } from '../../../customPropTypes'
 import makeFriendlyBalance from '../../../utils/makeFriendlyBalance'
 import { useConverter } from '../../../lib/Converter'
@@ -27,16 +27,16 @@ const BalanceCard = forwardRef(
       >
         <Label>Balance</Label>
         <Box overflow='hidden'>
-          <BigTitle color='card.balance.color'>
+          <HugeNumber color='card.balance.color'>
             {makeFriendlyBalance(balance, 5)}FIL
-          </BigTitle>
+          </HugeNumber>
           {!converter && !converterError ? (
-            <Title color='card.balance.color'>Loading USD</Title>
+            <BigNumber color='core.darkgray'>Loading USD</BigNumber>
           ) : (
-            <Title color='card.balance.color'>
+            <BigNumber color='core.darkgray'>
               {makeFriendlyBalance(converter.fromFIL(balance.toFil()))}
               USD
-            </Title>
+            </BigNumber>
           )}
         </Box>
         <Box display='flex' justifyContent='space-between'>

--- a/components/Shared/BalanceCard/index.jsx
+++ b/components/Shared/BalanceCard/index.jsx
@@ -1,9 +1,8 @@
 import React, { forwardRef } from 'react'
 import { func, bool } from 'prop-types'
-// import { BigNumber } from '@openworklabs/filecoin-number'
 import Box from '../Box'
 import Button from '../Button'
-import { HugeNumber, BigNumber, Title, Label } from '../Typography'
+import { Num, Label } from '../Typography'
 import { FILECOIN_NUMBER_PROP } from '../../../customPropTypes'
 import makeFriendlyBalance from '../../../utils/makeFriendlyBalance'
 import { useConverter } from '../../../lib/Converter'
@@ -27,16 +26,18 @@ const BalanceCard = forwardRef(
       >
         <Label>Balance</Label>
         <Box overflow='hidden'>
-          <HugeNumber color='card.balance.color'>
+          <Num size='xl' color='card.balance.color'>
             {makeFriendlyBalance(balance, 5)}FIL
-          </HugeNumber>
+          </Num>
           {!converter && !converterError ? (
-            <BigNumber color='core.darkgray'>Loading USD</BigNumber>
+            <Num size='l' color='core.darkgray'>
+              Loading USD
+            </Num>
           ) : (
-            <BigNumber color='core.darkgray'>
+            <Num size='l' color='core.darkgray'>
               {makeFriendlyBalance(converter.fromFIL(balance.toFil()))}
               USD
-            </BigNumber>
+            </Num>
           )}
         </Box>
         <Box display='flex' justifyContent='space-between'>

--- a/components/Shared/Typography/index.jsx
+++ b/components/Shared/Typography/index.jsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { color, typography, layout, space } from 'styled-system'
 import styled from 'styled-components'
-import { node } from 'prop-types'
+import { node, oneOf } from 'prop-types'
 
 import theme from '../theme'
 
@@ -67,20 +67,13 @@ export const Label = forwardRef(({ children, ...props }, ref) => (
 
 Label.propTypes = { children: node.isRequired }
 
-export const HugeNumber = forwardRef(({ children, ...props }, ref) => (
-  <H2Base ref={ref} {...theme.textStyles.hugeNumber} {...props}>
+export const Num = forwardRef(({ children, size, ...props }, ref) => (
+  <H2Base ref={ref} {...theme.textStyles.num[size]} {...props}>
     {children}
   </H2Base>
 ))
 
-// Start number styles
-
-HugeNumber.propTypes = { children: node.isRequired }
-
-export const BigNumber = forwardRef(({ children, ...props }, ref) => (
-  <H2Base ref={ref} {...theme.textStyles.bigNumber} {...props}>
-    {children}
-  </H2Base>
-))
-
-BigNumber.propTypes = { children: node.isRequired }
+Num.propTypes = {
+  children: node.isRequired,
+  size: oneOf(Object.keys(theme.textStyles.num))
+}

--- a/components/Shared/Typography/index.jsx
+++ b/components/Shared/Typography/index.jsx
@@ -66,3 +66,21 @@ export const Label = forwardRef(({ children, ...props }, ref) => (
 ))
 
 Label.propTypes = { children: node.isRequired }
+
+export const HugeNumber = forwardRef(({ children, ...props }, ref) => (
+  <H2Base ref={ref} {...theme.textStyles.hugeNumber} {...props}>
+    {children}
+  </H2Base>
+))
+
+// Start number styles
+
+HugeNumber.propTypes = { children: node.isRequired }
+
+export const BigNumber = forwardRef(({ children, ...props }, ref) => (
+  <H2Base ref={ref} {...theme.textStyles.bigNumber} {...props}>
+    {children}
+  </H2Base>
+))
+
+BigNumber.propTypes = { children: node.isRequired }

--- a/components/Shared/theme.js
+++ b/components/Shared/theme.js
@@ -143,7 +143,7 @@ const theme = {
       fontWeight: 700,
       margin: 0,
       lineHeight: 'title',
-      fontFamily: 'RT-Alias-Medium'
+      fontFamily: 'RT-Alias-Grotesk'
     },
     text: {
       fontSize: 3,
@@ -158,6 +158,20 @@ const theme = {
       fontWeight: 400,
       lineHeight: 'solid',
       fontFamily: 'RT-Alias-Grotesk'
+    },
+    hugeNumber: {
+      fontSize: 6,
+      fontWeight: 700,
+      margin: 0,
+      lineHeight: 'solid',
+      fontFamily: 'RT-Alias-Medium'
+    },
+    bigNumber: {
+      fontSize: 5,
+      fontWeight: 700,
+      margin: 0,
+      lineHeight: 'title',
+      fontFamily: 'RT-Alias-Medium'
     }
   },
   fonts: {

--- a/components/Shared/theme.js
+++ b/components/Shared/theme.js
@@ -159,19 +159,21 @@ const theme = {
       lineHeight: 'solid',
       fontFamily: 'RT-Alias-Grotesk'
     },
-    hugeNumber: {
-      fontSize: 6,
-      fontWeight: 700,
-      margin: 0,
-      lineHeight: 'solid',
-      fontFamily: 'RT-Alias-Medium'
-    },
-    bigNumber: {
-      fontSize: 5,
-      fontWeight: 700,
-      margin: 0,
-      lineHeight: 'title',
-      fontFamily: 'RT-Alias-Medium'
+    num: {
+      l: {
+        fontSize: 5,
+        fontWeight: 700,
+        margin: 0,
+        lineHeight: 'title',
+        fontFamily: 'RT-Alias-Medium'
+      },
+      xl: {
+        fontSize: 6,
+        fontWeight: 700,
+        margin: 0,
+        lineHeight: 'solid',
+        fontFamily: 'RT-Alias-Medium'
+      }
     }
   },
   fonts: {


### PR DESCRIPTION
# Changes

## Theme
Adds `HugeNumber` and `BigNumber` text styles, freeing us up to separate number and text styling.

## Typography
Adds these text styles as components and refs their objects in the theme file.

## BalanceCard
Adds the new typography components to the balance card & updates the USD balance color.

![image](https://user-images.githubusercontent.com/6787950/76965311-d73a6180-6902-11ea-9fe3-1a4a5c7ce4a8.png)
