### PR TITLE
Update Send Flow, Gas Customization based on JV feedback.

### DIFF
--- a/components/Shared/IconButtons/index.jsx
+++ b/components/Shared/IconButtons/index.jsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import styled from 'styled-components'
 import { func, object } from 'prop-types'
-import { layout, space, border } from 'styled-system'
+import { layout, space, border, flexbox } from 'styled-system'
 import { IconClose, IconCopyAccountAddress } from '../Icons'
 
 const IconButtonBase = styled.button`
@@ -17,6 +17,7 @@ const IconButtonBase = styled.button`
   ${layout}
   ${space}
   ${border}
+  ${flexbox}
 `
 
 const IconButton = forwardRef(({ onClick, Icon, ...props }, ref) => (

--- a/components/Wallet/Send.js/GasCustomization.jsx
+++ b/components/Wallet/Send.js/GasCustomization.jsx
@@ -61,17 +61,6 @@ const GasCustomization = ({
 
   return (
     <ContentContainer>
-      <Text>Would you like to manually set your transaction speed?</Text>
-      <Text
-        mt={0}
-        color='core.primary'
-        css={`
-          text-decoration: underline;
-          cursor: pointer;
-        `}
-      >
-        What's this?
-      </Text>
       {/* <Label mt={3} mb={3}>
         Select a preset transfer speed
       </Label>
@@ -129,9 +118,21 @@ const GasCustomization = ({
           type='button'
         />
       </Box> */}
-      <Label mt={3} mb={3}>
-        Submit a custom fee
-      </Label>
+      <Box display='flex' justifyContent='space-between' alignItems='center'>
+        <Label mt={3} mb={3}>
+          Submit a custom fee
+        </Label>
+        <Label
+          mt={0}
+          color='core.primary'
+          css={`
+            text-decoration: underline;
+            cursor: pointer;
+          `}
+        >
+          What's this?
+        </Label>
+      </Box>
       <Input.Number
         mt={2}
         m='0'

--- a/components/Wallet/Send.js/GasCustomization.jsx
+++ b/components/Wallet/Send.js/GasCustomization.jsx
@@ -7,6 +7,7 @@ import {
   Input,
   Label,
   Title,
+  Text,
   FloatingContainer,
   ContentContainer
 } from '../../Shared'
@@ -60,7 +61,18 @@ const GasCustomization = ({
 
   return (
     <ContentContainer>
-      <Label mt={3} mb={3}>
+      <Text>Would you like to manually set your transaction speed?</Text>
+      <Text
+        mt={0}
+        color='core.primary'
+        css={`
+          text-decoration: underline;
+          cursor: pointer;
+        `}
+      >
+        What's this?
+      </Text>
+      {/* <Label mt={3} mb={3}>
         Select a preset transfer speed
       </Label>
       <Box mb={4} display='flex' flexDirection='row'>
@@ -116,7 +128,7 @@ const GasCustomization = ({
           py={1}
           type='button'
         />
-      </Box>
+      </Box> */}
       <Label mt={3} mb={3}>
         Submit a custom fee
       </Label>
@@ -149,7 +161,7 @@ const GasCustomization = ({
         mt={7}
         mx={1}
       >
-        <Label>New Transaction Fee</Label>
+        <Title>New Transaction Fee</Title>
         <Box display='flex' flexDirection='column' LabelAlign='right'>
           <Title fontSize={4} color='core.primary'>
             {estimatedGas
@@ -165,7 +177,7 @@ const GasCustomization = ({
           borderRadius={0}
           borderColor='core.lightgray'
           type='button'
-          title='Cancel'
+          title='Back'
           variant='secondary'
           onClick={() => {
             exit()

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -311,7 +311,7 @@ const Send = ({ close }) => {
                   `}
                   onClick={() => setCustomizingGas(true)}
                 >
-                  Adjust transfer fee
+                  Advanced
                 </Text>
               </Box>
               <Box

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -392,12 +392,6 @@ const Send = ({ close }) => {
           )}
         </SendCardForm>
       </SendContainer>
-      <ButtonClose
-        alignSelf='flex-start'
-        ml={2}
-        type='button'
-        onClick={close}
-      />
     </>
   )
 }

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -19,7 +19,7 @@ import {
   Button,
   Title,
   FloatingContainer,
-  Label as Total,
+  Title as Total,
   ContentContainer as SendContainer
 } from '../../Shared'
 import { ButtonClose } from '../../Shared/IconButtons'
@@ -211,180 +211,194 @@ const Send = ({ close }) => {
     wallet.type === LEDGER && reportLedgerConfigError(ledger)
 
   return (
-    <SendContainer>
-      {hasError() && (
-        <ErrorCard
-          error={ledgerError() || uncaughtError}
-          reset={() => {
-            setAttemptingTx(false)
-            setUncaughtError('')
-            resetLedgerState()
-            setStep(1)
-          }}
-        />
-      )}
-      {(step === 2 || step === 3) && !hasError() && (
-        <ConfirmationCard
-          walletType={wallet.type}
-          value={value}
-          toAddress={toAddress}
-        />
-      )}
-      <SendCardForm onSubmit={onSubmit} autoComplete='off'>
-        <Box display='flex' alignItems='center' justifyContent='space-between'>
-          <Box display='flex' alignItems='center'>
-            <Glyph
-              acronym='To'
-              color='background.screen'
-              borderColor='core.primary'
-              backgroundColor='core.primary'
-            />
-            <Text color='core.primary' ml={2}>
-              Sending Filecoin
-            </Text>
-          </Box>
-          <Box display='flex' alignItems='center'>
-            <Stepper
-              textColor='core.primary'
-              completedDotColor='core.primary'
-              incompletedDotColor='core.silver'
-              step={1}
-              totalSteps={2}
-              mr={2}
-            >
-              Step 1
-            </Stepper>
-            <ButtonClose ml={2} type='button' onClick={close} />
-          </Box>
-        </Box>
-        <Box mt={3}>
-          {customizingGas ? (
-            <GasCustomization
-              estimateGas={estimateGas}
-              exit={() => setCustomizingGas(false)}
-              gasPrice={gasPrice}
-              gasLimit={gasLimit}
-              setGasPrice={setGasPrice}
-              setGasLimit={setGasLimit}
-            />
-          ) : (
-            <>
-              <Input.Address
-                name='recipient'
-                onChange={e => setToAddress(e.target.value)}
-                value={toAddress}
-                label='Recipient'
-                placeholder='t1...'
-                error={toAddressError}
-                setError={setToAddressError}
-                disabled={step === 2 && !hasError()}
-                valid={validateAddressString(toAddress)}
+    <>
+      <SendContainer>
+        {hasError() && (
+          <ErrorCard
+            error={ledgerError() || uncaughtError}
+            reset={() => {
+              setAttemptingTx(false)
+              setUncaughtError('')
+              resetLedgerState()
+              setStep(1)
+            }}
+          />
+        )}
+        {(step === 2 || step === 3) && !hasError() && (
+          <ConfirmationCard
+            walletType={wallet.type}
+            value={value}
+            toAddress={toAddress}
+          />
+        )}
+        <SendCardForm onSubmit={onSubmit} autoComplete='off'>
+          <Box
+            display='flex'
+            alignItems='center'
+            justifyContent='space-between'
+          >
+            <Box display='flex' alignItems='center'>
+              <Glyph
+                acronym='To'
+                color='background.screen'
+                borderColor='core.primary'
+                backgroundColor='core.primary'
               />
-              <Input.Funds
-                name='amount'
-                label='Amount'
-                amount={value.fil.toAttoFil()}
-                onAmountChange={setValue}
-                balance={wallet.balance}
-                error={valueError}
-                setError={setValueError}
-                gasLimit={gasLimit}
-                disabled={step === 2 && !hasError()}
-                valid={isValidAmount(value.fil, wallet.balance, valueError)}
-              />
-              <Box display='flex' flexDirection='column'>
-                <Input.Text
-                  onChange={() => {}}
-                  label='Transfer Fee'
-                  value='< 0.1FIL'
-                  backgroundColor='background.screen'
-                  disabled
-                />
-                <Text
-                  color='core.primary'
-                  css={`
-                    &:hover {
-                      cursor: pointer;
-                    }
-                    text-decoration: underline;
-                    align-self: flex-end;
-                  `}
-                  onClick={() => setCustomizingGas(true)}
-                >
-                  Advanced
-                </Text>
-              </Box>
-              <Box
-                display='flex'
-                flexDirection='row'
-                alignItems='center'
-                justifyContent='space-between'
-                mt={3}
-                mx={1}
-              >
-                <Total fontSize={4}>Total</Total>
-                <Box display='flex' flexDirection='column' textAlign='right'>
-                  <BigTitle color='core.primary'>
-                    {makeFriendlyBalance(new BigNumber(value.fil.toFil()), 10)}{' '}
-                    FIL
-                  </BigTitle>
-                  <Title color='core.darkgray'>
-                    {makeFriendlyBalance(value.fiat, 7)} USD
-                  </Title>
-                </Box>
-              </Box>
-            </>
-          )}
-        </Box>
-        {!customizingGas && (
-          <FloatingContainer>
-            {step === 2 && wallet.type === LEDGER ? (
-              <Text width='100%' textAlign='center' px={4}>
-                Confirm or reject the transaction on your Ledger Device.
+              <Text color='core.primary' ml={2}>
+                Sending Filecoin
               </Text>
+            </Box>
+            <Box display='flex' alignItems='center'>
+              <Stepper
+                textColor='core.primary'
+                completedDotColor='core.primary'
+                incompletedDotColor='core.silver'
+                step={1}
+                totalSteps={2}
+                mr={2}
+              >
+                Step 1
+              </Stepper>
+            </Box>
+          </Box>
+          <Box mt={3}>
+            {customizingGas ? (
+              <GasCustomization
+                estimateGas={estimateGas}
+                exit={() => setCustomizingGas(false)}
+                gasPrice={gasPrice}
+                gasLimit={gasLimit}
+                setGasPrice={setGasPrice}
+                setGasLimit={setGasLimit}
+              />
             ) : (
               <>
-                <Button
-                  type='button'
-                  title='Cancel'
-                  variant='secondary'
-                  border={0}
-                  borderRight={1}
-                  borderRadius={0}
-                  borderColor='core.lightgray'
-                  onClick={() => {
-                    setAttemptingTx(false)
-                    setUncaughtError('')
-                    resetLedgerState()
-                    close()
-                  }}
+                <Input.Address
+                  name='recipient'
+                  onChange={e => setToAddress(e.target.value)}
+                  value={toAddress}
+                  label='Recipient'
+                  placeholder='t1...'
+                  error={toAddressError}
+                  setError={setToAddressError}
+                  disabled={step === 2 && !hasError()}
+                  valid={validateAddressString(toAddress)}
                 />
-                <Button
-                  border={0}
-                  borderRadius={0}
-                  disabled={
-                    !!(
-                      hasError() ||
-                      !isValidForm(
-                        toAddress,
-                        value.fil,
-                        wallet.balance,
-                        toAddressError,
-                        valueError
-                      )
-                    )
-                  }
-                  type='submit'
-                  title={step === 1 ? 'Next' : 'Confirm'}
-                  variant='primary'
-                  onClick={() => {}}
+                <Input.Funds
+                  name='amount'
+                  label='Amount'
+                  amount={value.fil.toAttoFil()}
+                  onAmountChange={setValue}
+                  balance={wallet.balance}
+                  error={valueError}
+                  setError={setValueError}
+                  gasLimit={gasLimit}
+                  disabled={step === 2 && !hasError()}
+                  valid={isValidAmount(value.fil, wallet.balance, valueError)}
                 />
+                <Box display='flex' flexDirection='column'>
+                  <Input.Text
+                    onChange={() => {}}
+                    label='Transfer Fee'
+                    value='< 0.1FIL'
+                    backgroundColor='background.screen'
+                    disabled
+                  />
+                  <Text
+                    color='core.primary'
+                    css={`
+                      &:hover {
+                        cursor: pointer;
+                      }
+                      text-decoration: underline;
+                      align-self: flex-end;
+                    `}
+                    onClick={() => setCustomizingGas(true)}
+                  >
+                    Advanced
+                  </Text>
+                </Box>
+                <Box
+                  display='flex'
+                  flexDirection='row'
+                  alignItems='center'
+                  justifyContent='space-between'
+                  mt={3}
+                  mx={1}
+                >
+                  <Total fontSize={4}>Total</Total>
+                  <Box display='flex' flexDirection='column' textAlign='right'>
+                    <BigTitle color='core.primary'>
+                      {makeFriendlyBalance(
+                        new BigNumber(value.fil.toFil()),
+                        10
+                      )}{' '}
+                      FIL
+                    </BigTitle>
+                    <Title color='core.darkgray'>
+                      {makeFriendlyBalance(value.fiat, 7)} USD
+                    </Title>
+                  </Box>
+                </Box>
               </>
             )}
-          </FloatingContainer>
-        )}
-      </SendCardForm>
-    </SendContainer>
+          </Box>
+          {!customizingGas && (
+            <FloatingContainer>
+              {step === 2 && wallet.type === LEDGER ? (
+                <Text width='100%' textAlign='center' px={4}>
+                  Confirm or reject the transaction on your Ledger Device.
+                </Text>
+              ) : (
+                <>
+                  <Button
+                    type='button'
+                    title='Cancel'
+                    variant='secondary'
+                    border={0}
+                    borderRight={1}
+                    borderRadius={0}
+                    borderColor='core.lightgray'
+                    onClick={() => {
+                      setAttemptingTx(false)
+                      setUncaughtError('')
+                      resetLedgerState()
+                      close()
+                    }}
+                  />
+                  <Button
+                    border={0}
+                    borderRadius={0}
+                    disabled={
+                      !!(
+                        hasError() ||
+                        !isValidForm(
+                          toAddress,
+                          value.fil,
+                          wallet.balance,
+                          toAddressError,
+                          valueError
+                        )
+                      )
+                    }
+                    type='submit'
+                    title={step === 1 ? 'Next' : 'Confirm'}
+                    variant='primary'
+                    onClick={() => {}}
+                  />
+                </>
+              )}
+            </FloatingContainer>
+          )}
+        </SendCardForm>
+      </SendContainer>
+      <ButtonClose
+        alignSelf='flex-start'
+        ml={2}
+        type='button'
+        onClick={close}
+      />
+    </>
   )
 }
 


### PR DESCRIPTION
# Changes
1. `SendCard` 'Total' font size increased
1. Moved `ButtonClose` outside `SendCard`
1. Renamed 'Custom Gas' copy to 'Advanced'
1. Commented out gas customization preset buttons
1. Added copywriting
1. Added **(non-functional)** 'link' to provide more information for users.


# Did Not Do
1. Add tooltips to communciate Gas Customization terms/concepts. This is something I want to figure out with you. Do we link out to support docs instead, where we can provide more information?


# Screenshots
![image](https://user-images.githubusercontent.com/6787950/78040732-3908bb80-7346-11ea-953d-9441db7eb0bc.png)

![image](https://user-images.githubusercontent.com/6787950/78040758-40c86000-7346-11ea-849f-79965059c51e.png)


# To Do
1. `ButtonClose`'s `onClick` should be conditional: It should close the 'Send Flow' and take the user "Home" if the user clicks on while on the main Send flow screen. **IF** The user is in the Gas customization screen, it should take them back to the main Send flow screen.
1. Link out the "What's this?" helper text to an educational source (or trigger tooltips maybe if we decide to add those in - discussion needs to be had on this).