### PR TITLE
Style/updated account selector

### DIFF
--- a/components/AccountSelector/__snapshots__/index.test.js.snap
+++ b/components/AccountSelector/__snapshots__/index.test.js.snap
@@ -72,8 +72,9 @@ Array [
             Your single seed phrase creates hundreds of individual "accounts".
             <br />
             <a
-              className="Link__StyledATag-sc-11kjldy-0 kCLHyJ"
+              className="Link__StyledATag-sc-11kjldy-0 gURXXN"
               color="core.primary"
+              fontSize={3}
               href="/faqs"
               rel="noopener"
               target="_blank"
@@ -243,7 +244,7 @@ Array [
             </div>
           </div>
           <div
-            className="Box-tuskkk-0 iBIMkc"
+            className="Box-tuskkk-0 eXipjK"
             color="card.error.foreground"
             display="flex"
             height={11}
@@ -254,8 +255,8 @@ Array [
               display="flex"
             >
               <div
-                className="Box-tuskkk-0 ilXArz"
-                color="#000"
+                className="Box-tuskkk-0 cAONNH"
+                color="status.fail.foreground"
                 display="flex"
                 size={6}
               >
@@ -291,8 +292,10 @@ Array [
               display="flex"
             >
               <button
-                className="BaseButton-sc-1iyr4rl-0 cwpdtc"
+                className="BaseButton-sc-1iyr4rl-0 cxMAgW"
+                color="status.fail.foreground"
                 fontSize={3}
+                height="100%"
                 onClick={[Function]}
               >
                 Try again
@@ -378,8 +381,9 @@ Array [
             Your single seed phrase creates hundreds of individual "accounts".
             <br />
             <a
-              className="Link__StyledATag-sc-11kjldy-0 kCLHyJ"
+              className="Link__StyledATag-sc-11kjldy-0 gURXXN"
               color="core.primary"
+              fontSize={3}
               href="/faqs"
               rel="noopener"
               target="_blank"

--- a/components/AccountSelector/index.jsx
+++ b/components/AccountSelector/index.jsx
@@ -127,7 +127,7 @@ const AccountSelector = () => {
               {walletsInRdx.map((w, i) => (
                 <AccountCardAlt
                   alignItems='center'
-                  onClick={() => dispatch(switchWallet(i))}
+                  onClick={() => dispatch(switchWallet(i), onClose())}
                   key={w.address}
                   address={w.address}
                   index={i}

--- a/components/Shared/AccountCard/Error.jsx
+++ b/components/Shared/AccountCard/Error.jsx
@@ -17,17 +17,25 @@ const AccountError = ({ errorMsg, onTryAgain }) => (
     bg='card.error.background'
     color='card.error.foreground'
     boxShadow={1}
-    mb={2}
+    m={2}
   >
     <Box display='flex' alignItems='center' justifyContent='flex-start'>
-      <Glyph mr={3} acronym='Er' />
+      <Glyph mr={3} acronym='Er' color='status.fail.foreground' />
       <Text>Error</Text>
     </Box>
     <Box>
       <Text margin={0}>{errorMsg}</Text>
     </Box>
     <Box display='flex'>
-      <Button variant='tertiary' title='Try again' onClick={onTryAgain} p={2} />
+      <Button
+        title='Try again'
+        onClick={onTryAgain}
+        height='100%'
+        backgroundColor='core.transparent'
+        borderColor='status.fail.foreground'
+        color='status.fail.foreground'
+        p={2}
+      />
     </Box>
   </Box>
 )

--- a/components/Shared/Link/index.jsx
+++ b/components/Shared/Link/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 
 export const StyledATag = styled.a.attrs(props => ({
   color: 'core.primary',
+  fontSize: 3,
   ...props
 }))`
   ${color}


### PR DESCRIPTION
- Update `StyledATag` component font-size to match `Text` component.
![image](https://user-images.githubusercontent.com/6787950/78560754-f3883a80-77ec-11ea-9398-7ec9c7eb07c0.png)

- Updated `ErrorCard` styling, positioning
![image](https://user-images.githubusercontent.com/6787950/78560896-2b8f7d80-77ed-11ea-8e66-030bf600ea72.png)

- Added `onClose` function to direct users to the home screen when they select an account.

# Tested

## Ledger
Disconnect Ledger device ✅ 

Reconnect disconnected Ledger device & click `ErrorCard` Try Again button ✅ 

"Ledger is busy" test ❌ 
1. Create a tx to send
1. Do not confirm tx
1. Access `AccountSelector` page
1. Click "Create Account" button
1. Loading Card displays, but nothing happens.
1. No error is presented.

Create Account after canceling pending tx on Ledger ✅ 

# Create w/ Menmonic

Create accounts ✅ 
Switch accounts ✅ 

# Import Mnemonic

Create accounts ✅ 
Switch accounts ✅ 

# Import Private Key

Switch account button not visible ✅ 