### PR TITLE
Update/confirmation card

### DIFF
--- a/components/Wallet/Send.js/ConfirmationCard.jsx
+++ b/components/Wallet/Send.js/ConfirmationCard.jsx
@@ -27,6 +27,7 @@ const LedgerConfirm = () => {
       <Text color='core.nearblack'>
         To send the transaction, please
         <TextHighlight>
+          {' '}
           confirm the transfer on your Ledger device.
         </TextHighlight>
       </Text>

--- a/components/Wallet/Send.js/ConfirmationCard.jsx
+++ b/components/Wallet/Send.js/ConfirmationCard.jsx
@@ -9,10 +9,6 @@ import {
   CREATE_MNEMONIC,
   IMPORT_SINGLE_KEY
 } from '../../../constants'
-import {
-  FILECOIN_NUMBER_PROP,
-  ADDRESS_PROPTYPE
-} from '../../../customPropTypes'
 
 const TextHighlight = styled.span.attrs(() => ({
   fontSize: 3,
@@ -35,28 +31,24 @@ const LedgerConfirm = () => {
   )
 }
 
-const OtherWalletTypeConfirm = ({ toAddress, value }) => {
+const OtherWalletTypeConfirm = () => {
   return (
     <>
       <Text color='core.nearblack'>
-        To send the transaction, please review the
-        <TextHighlight>recipient</TextHighlight> and
-        <TextHighlight>amount</TextHighlight> and click the Confirm button at
+        To complete the transaction, please review the{' '}
+        <TextHighlight>recipient</TextHighlight> and{' '}
+        <TextHighlight>amount</TextHighlight> and click &rdquo;Confirm&rdquo; at
         the bottom of the page.
       </Text>
-      <Text>Remember: You cannot undo this transaction once you send it.</Text>
+      <Text>
+        <TextHighlight>Remember:</TextHighlight> Transactions are{' '}
+        <TextHighlight>final once sent.</TextHighlight>
+      </Text>
     </>
   )
 }
 
-OtherWalletTypeConfirm.propTypes = {
-  value: PropTypes.shape({
-    fil: FILECOIN_NUMBER_PROP
-  }).isRequired,
-  toAddress: ADDRESS_PROPTYPE
-}
-
-const ConfirmationCard = ({ value, walletType, toAddress }) => {
+const ConfirmationCard = ({ walletType }) => {
   return (
     <Card
       display='flex'
@@ -87,26 +79,18 @@ const ConfirmationCard = ({ value, walletType, toAddress }) => {
           </Text>
         </Box>
       </Box>
-      {walletType === LEDGER ? (
-        <LedgerConfirm />
-      ) : (
-        <OtherWalletTypeConfirm value={value} toAddress={toAddress} />
-      )}
+      {walletType === LEDGER ? <LedgerConfirm /> : <OtherWalletTypeConfirm />}
     </Card>
   )
 }
 
 ConfirmationCard.propTypes = {
-  value: PropTypes.shape({
-    fil: FILECOIN_NUMBER_PROP
-  }).isRequired,
   walletType: PropTypes.oneOf([
     LEDGER,
     IMPORT_MNEMONIC,
     CREATE_MNEMONIC,
     IMPORT_SINGLE_KEY
-  ]).isRequired,
-  toAddress: ADDRESS_PROPTYPE
+  ]).isRequired
 }
 
 export default ConfirmationCard

--- a/components/Wallet/Send.js/ConfirmationCard.jsx
+++ b/components/Wallet/Send.js/ConfirmationCard.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { typography } from 'styled-system'
 import PropTypes from 'prop-types'
-import { Box, Card, Glyph, Text } from '../../Shared'
+import { Box, Card, Glyph, Text, Stepper } from '../../Shared'
 import {
   LEDGER,
   IMPORT_MNEMONIC,
@@ -64,9 +64,10 @@ const ConfirmationCard = ({ walletType }) => {
         flexDirection='row'
         border='none'
         width='auto'
+        alignItems='center'
         justifyContent='space-between'
       >
-        <Box display='flex' alignItems='center'>
+        <Box display='flex' flexDirection='row' alignItems='center'>
           <Glyph
             acronym='Cf'
             textAlign='center'
@@ -77,6 +78,16 @@ const ConfirmationCard = ({ walletType }) => {
           <Text color='card.confirmation.foreground' ml={2}>
             Confirmation
           </Text>
+        </Box>
+        <Box display='flex' alignItems='center'>
+          <Stepper
+            textColor='card.confirmation.foreground'
+            completedDotColor='card.confirmation.foreground'
+            incompletedDotColor='core.silver'
+            step={2}
+            totalSteps={2}
+          />
+          <Box width={5} mx={2} />
         </Box>
       </Box>
       {walletType === LEDGER ? <LedgerConfirm /> : <OtherWalletTypeConfirm />}

--- a/components/Wallet/Send.js/ConfirmationCard.jsx
+++ b/components/Wallet/Send.js/ConfirmationCard.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import styled from 'styled-components'
+import { typography } from 'styled-system'
 import PropTypes from 'prop-types'
-import { Box, Card, Input, Glyph, Stepper, Text } from '../../Shared'
+import { Box, Card, Glyph, Text } from '../../Shared'
 import {
   LEDGER,
   IMPORT_MNEMONIC,
@@ -12,20 +14,21 @@ import {
   ADDRESS_PROPTYPE
 } from '../../../customPropTypes'
 
+const TextHighlight = styled.span.attrs(() => ({
+  fontSize: 3,
+  fontWeight: 2
+}))`
+  ${typography}
+`
+
 const LedgerConfirm = () => {
   return (
     <>
-      <Text color='core.nearblack'>Thank you.</Text>
       <Text color='core.nearblack'>
-        To send the transaction,{' '}
-        <span
-          css={`
-            font-size: 1.25rem;
-            font-weight: 600;
-          `}
-        >
+        To send the transaction, please
+        <TextHighlight>
           confirm the transfer on your Ledger device.
-        </span>
+        </TextHighlight>
       </Text>
     </>
   )
@@ -34,21 +37,13 @@ const LedgerConfirm = () => {
 const OtherWalletTypeConfirm = ({ toAddress, value }) => {
   return (
     <>
-      <Text color='core.nearblack'>Please confirm that you want to:</Text>
-      <Input.Text
-        disabled
-        backgroundColor='card.confirmation.background'
-        color='card.confirmation.foreground'
-        label='Sending'
-        value={value.fil.toFil()}
-      />
-      <Input.Address
-        disabled
-        backgroundColor='card.confirmation.background'
-        color='card.confirmation.foreground'
-        label='To'
-        value={toAddress}
-      />
+      <Text color='core.nearblack'>
+        To send the transaction, please review the
+        <TextHighlight>recipient</TextHighlight> and
+        <TextHighlight>amount</TextHighlight> and click the Confirm button at
+        the bottom of the page.
+      </Text>
+      <Text>Remember: You cannot undo this transaction once you send it.</Text>
     </>
   )
 }
@@ -90,15 +85,6 @@ const ConfirmationCard = ({ value, walletType, toAddress }) => {
             Confirmation
           </Text>
         </Box>
-        <Stepper
-          textColor='card.confirmation.foreground'
-          completedDotColor='card.confirmation.foreground'
-          incompletedDotColor='core.silver'
-          step={2}
-          totalSteps={2}
-        >
-          Step 2
-        </Stepper>
       </Box>
       {walletType === LEDGER ? (
         <LedgerConfirm />

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -20,7 +20,8 @@ import {
   Title,
   FloatingContainer,
   Title as Total,
-  ContentContainer as SendContainer
+  ContentContainer as SendContainer,
+  Stepper
 } from '../../Shared'
 import ConfirmationCard from './ConfirmationCard'
 import GasCustomization from './GasCustomization'
@@ -247,6 +248,14 @@ const Send = ({ close }) => {
               </Text>
             </Box>
             <Box display='flex' alignItems='center'>
+              <Stepper
+                textColor='core.primary'
+                completedDotColor='core.primary'
+                incompletedDotColor='core.silver'
+                step={1}
+                totalSteps={2}
+                mr={2}
+              />
               <ButtonClose
                 role='button'
                 type='button'
@@ -360,7 +369,7 @@ const Send = ({ close }) => {
                 <>
                   <Button
                     type='button'
-                    title='Cancel'
+                    title='Back'
                     variant='secondary'
                     border={0}
                     borderRight={1}

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -8,11 +8,11 @@ import { FilecoinNumber, BigNumber } from '@openworklabs/filecoin-number'
 import { validateAddressString } from '@openworklabs/filecoin-address'
 import Message from '@openworklabs/filecoin-message'
 import makeFriendlyBalance from '../../../utils/makeFriendlyBalance'
+import noop from '../../../utils/noop'
 
 import {
   Box,
   Input,
-  Stepper,
   Glyph,
   Text,
   Button,
@@ -247,15 +247,16 @@ const Send = ({ close }) => {
               </Text>
             </Box>
             <Box display='flex' alignItems='center'>
-              <Stepper
-                textColor='core.primary'
-                completedDotColor='core.primary'
-                incompletedDotColor='core.silver'
-                step={step === 1 ? 1 : 2}
-                totalSteps={2}
-                mr={2}
+              <ButtonClose
+                role='button'
+                type='button'
+                onClick={() => {
+                  setAttemptingTx(false)
+                  setUncaughtError('')
+                  resetLedgerState()
+                  close()
+                }}
               />
-              <ButtonClose />
             </Box>
           </Box>
           <Box mt={3}>
@@ -359,17 +360,20 @@ const Send = ({ close }) => {
                 <>
                   <Button
                     type='button'
-                    title={step === 1 ? 'Cancel' : 'Back'}
+                    title='Cancel'
                     variant='secondary'
                     border={0}
                     borderRight={1}
                     borderRadius={0}
                     borderColor='core.lightgray'
                     onClick={() => {
-                      setAttemptingTx(false)
-                      setUncaughtError('')
-                      resetLedgerState()
-                      close()
+                      if (step === 2) setStep(1)
+                      else {
+                        setAttemptingTx(false)
+                        setUncaughtError('')
+                        resetLedgerState()
+                        close()
+                      }
                     }}
                     css={`
                       /* 'css' operation is used here to override its inherited border-radius property */
@@ -394,7 +398,7 @@ const Send = ({ close }) => {
                     type='submit'
                     title={step === 1 ? 'Next' : 'Confirm'}
                     variant='primary'
-                    onClick={() => {}}
+                    onClick={noop}
                     css={`
                       /* 'css' operation is used here to override its inherited border-radius property */
                       border-radius: 0px;

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -251,12 +251,10 @@ const Send = ({ close }) => {
                 textColor='core.primary'
                 completedDotColor='core.primary'
                 incompletedDotColor='core.silver'
-                step={1}
+                step={step === 1 ? 1 : 2}
                 totalSteps={2}
                 mr={2}
-              >
-                Step 1
-              </Stepper>
+              />
               <ButtonClose />
             </Box>
           </Box>

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -227,11 +227,7 @@ const Send = ({ close }) => {
           />
         )}
         {(step === 2 || step === 3) && !hasError() && (
-          <ConfirmationCard
-            walletType={wallet.type}
-            value={value}
-            toAddress={toAddress}
-          />
+          <ConfirmationCard walletType={wallet.type} />
         )}
         <SendCardForm onSubmit={onSubmit} autoComplete='off'>
           <Box

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -16,6 +16,7 @@ import {
   Glyph,
   Text,
   Button,
+  ButtonClose,
   Title,
   FloatingContainer,
   Title as Total,
@@ -260,6 +261,7 @@ const Send = ({ close }) => {
               >
                 Step 1
               </Stepper>
+              <ButtonClose />
             </Box>
           </Box>
           <Box mt={3}>


### PR DESCRIPTION
Closes #332 

# Changes

## ConfirmationCard
1. Update copywriting
1. Remove `Stepper` component
1. Add `TextHighlight` component to highlight parts of the copy to infer visual significance to users.
1. Removed value/recipient 

## SendCard
1. Removed value/recipient props that were being passed down to the `ConfirmationCard`
1. Restored `ButtonClose` - it makes more sense now that the `ConfirmationCard` is simply a notification.
1. Updated the `Stepper` to display both Steps 1 and 2 (formerly, the `ConfirmationCard` only displayed Step 2)

## Todo

1. - [ ] Test the `ConfirmationCard` updates on a mnemonic (non-Ledger) account.

# Reference
![image](https://user-images.githubusercontent.com/6787950/78696615-0cb8e600-78d6-11ea-922f-69ca1e154c86.png)

