### PR TITLE
Add flex-wrap to establish responsiveness

### DIFF
--- a/components/Wallet/Send.js/ErrorCard.jsx
+++ b/components/Wallet/Send.js/ErrorCard.jsx
@@ -34,6 +34,7 @@ const ErrorCard = ({ error, reset }) => {
       </Box>
       <Box
         display='flex'
+        flexWrap='wrap'
         justifyContent='space-between'
         alignItems='center'
         flexGrow='2'


### PR DESCRIPTION
ErrorCard now wraps on small viewports.

![image](https://user-images.githubusercontent.com/6787950/78934035-9dcbc080-7a80-11ea-9136-54f971b81695.png)
