### PR TITLE
Update conditional styling of MnemonicInput bg/color

### DIFF
--- a/components/Shared/MnemonicWord/InputWord.jsx
+++ b/components/Shared/MnemonicWord/InputWord.jsx
@@ -96,6 +96,7 @@ const MnemonicWord = ({
         onChange={e => setWord(e.target.value)}
         completed={completed}
         value={word}
+        importSeedError={importSeedError}
       />
     </StyledWrapper>
   )

--- a/components/Shared/MnemonicWord/InputWord.jsx
+++ b/components/Shared/MnemonicWord/InputWord.jsx
@@ -15,15 +15,21 @@ import contentProps from './contentProps'
 
 const setBackgroundColor = ({ completed, empty, valid, importSeedError }) => {
   if (importSeedError && (empty || !valid)) return 'status.fail.background'
-  if (!importSeedError && completed) return 'core.primary'
+  if (!importSeedError && completed) return 'core.secondary'
   if (!importSeedError && empty) return 'core.white'
-  return 'core.white'
+  return 'core.secondary'
 }
 
-const setInputColor = props => {
-  if (props.completed) return 'core.white'
+const setInputColor = ({ completed, importSeedError }) => {
+  if (importSeedError) return 'status.fail.foreground'
+  if (!importSeedError && completed) return 'core.primary'
   return 'core.primary'
 }
+
+// const setInputColor = props => {
+//   if (props.completed) return 'core.white'
+//   return 'core.primary'
+// }
 
 export const MnemonicWordInput = styled.input.attrs(props => ({
   ...contentProps,

--- a/components/Shared/MnemonicWord/InputWord.jsx
+++ b/components/Shared/MnemonicWord/InputWord.jsx
@@ -21,15 +21,10 @@ const setBackgroundColor = ({ completed, empty, valid, importSeedError }) => {
 }
 
 const setInputColor = ({ completed, importSeedError }) => {
-  if (importSeedError) return 'status.fail.foreground'
+  if (importSeedError) return 'core.nearblack'
   if (!importSeedError && completed) return 'core.primary'
   return 'core.primary'
 }
-
-// const setInputColor = props => {
-//   if (props.completed) return 'core.white'
-//   return 'core.primary'
-// }
 
 export const MnemonicWordInput = styled.input.attrs(props => ({
   ...contentProps,


### PR DESCRIPTION
Closes #381 

<img width="853" alt="Screen Shot 2020-04-14 at 1 14 36 PM" src="https://user-images.githubusercontent.com/6787950/79248342-17352b80-7e52-11ea-95ec-a651f58ec76b.png">

# To Do
1. - [ ] Set input color to `core.nearblack` if `importSeedError` is true.

Example:
<img width="925" alt="Screen Shot 2020-04-14 at 1 18 12 PM" src="https://user-images.githubusercontent.com/6787950/79248678-81e66700-7e52-11ea-84b7-add6e6b29c89.png">
