### PR TITLE
Support large displays & update /onboarding copy

### DIFF
--- a/components/Onboarding/Choose/Hello.jsx
+++ b/components/Onboarding/Choose/Hello.jsx
@@ -4,6 +4,8 @@ import { Box, Text, BigTitle } from '../../Shared'
 export default ({ ...props }) => (
   <Box {...props}>
     <BigTitle>Glif</BigTitle>
-    <Text maxWidth={12}>How do you want to create your wallet?</Text>
+    <Text maxWidth={12}>
+      Create or login to your wallet to access the Filecoin network.
+    </Text>
   </Box>
 )

--- a/components/Onboarding/Choose/index.jsx
+++ b/components/Onboarding/Choose/index.jsx
@@ -78,7 +78,7 @@ export default () => {
                 onClick={() => onChoose(IMPORT_MNEMONIC)}
                 glyphAcronym='Sp'
                 title='Import Seed Phrase'
-                description='Use your existing seed phrase'
+                description='Use your existing seed phrase from Glif or another wallet'
                 m={2}
               />
               <ImportWallet

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -560,16 +560,6 @@ exports[`WalletView it renders correctly 1`] = `
   background: #C4C4C4;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
 .c1 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -598,6 +588,18 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0.5rem;
   min-width: 53%;
   margin-bottom: 6rem;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  max-width: 1440px;
+  margin: 0 auto;
 }
 
 .c36 {
@@ -631,7 +633,7 @@ exports[`WalletView it renders correctly 1`] = `
 }
 
 <div
-  class="c0"
+  class="SidebarLayout__Wrapper-gwfrwp-0 c0"
 >
   <div
     class="c1"
@@ -1558,16 +1560,6 @@ exports[`WalletView it renders the receive flow when a user clicks receive 1`] =
   background: #C4C4C4;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
 .c1 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1615,6 +1607,18 @@ exports[`WalletView it renders the receive flow when a user clicks receive 1`] =
   flex-direction: column;
 }
 
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
 .c36 {
   cursor: pointer;
   border: 1px solid #262626;
@@ -1646,7 +1650,7 @@ exports[`WalletView it renders the receive flow when a user clicks receive 1`] =
 }
 
 <div
-  class="c0"
+  class="SidebarLayout__Wrapper-gwfrwp-0 c0"
 >
   <div
     class="c1"
@@ -3126,16 +3130,6 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   background: #C4C4C4;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
 .c1 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -3269,6 +3263,18 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-radius: 0px;
 }
 
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
 .c36 {
   cursor: pointer;
   border: 1px solid #262626;
@@ -3300,7 +3306,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
 }
 
 <div
-  class="c0"
+  class="SidebarLayout__Wrapper-gwfrwp-0 c0"
 >
   <div
     class="c1"

--- a/components/Wallet/index.jsx
+++ b/components/Wallet/index.jsx
@@ -57,7 +57,7 @@ export default () => {
       <MsgConfirmer />
       <Wrapper
         css={`
-          /* Temp implementation to simplistically handle large scale displays. This should be removed and a more dynamic solution introduced  */
+          /* Temp implementation to simplistically handle large scale displays. This should be removed and a more dynamic solution introduced e.g https://css-tricks.com/optimizing-large-scale-displays/  */
           max-width: 1440px;
           margin: 0 auto;
         `}

--- a/components/Wallet/index.jsx
+++ b/components/Wallet/index.jsx
@@ -55,7 +55,13 @@ export default () => {
   return (
     <>
       <MsgConfirmer />
-      <Wrapper>
+      <Wrapper
+        css={`
+          /* Temp implementation to simplistically handle large scale displays. This should be removed and a more dynamic solution introduced  */
+          max-width: 1440px;
+          margin: 0 auto;
+        `}
+      >
         <Sidebar height='100vh'>
           <NetworkSwitcherGlyph />
           {hasLedgerError({ ...ledger, otherError: uncaughtError }) &&


### PR DESCRIPTION
Closes #274 

# Changes
1. Adds a hardcoded `max-width` and `margin` to constrain the app to 1440px and center its contents.
1. Updates copy on the `/onboarding` page to ref the Filecoin network
1. Updates copy of "Import seed phrase" to reduce ambiguity for users who create a wallet via mnemonic.

This is a simple, static implementation and we can invest resources into a more dynamic solution later (e.g. the recommendations here https://css-tricks.com/optimizing-large-scale-displays/

# Reference
@2560px
<img width="844" alt="Screen Shot 2020-04-15 at 12 49 30 PM" src="https://user-images.githubusercontent.com/6787950/79358433-92ace080-7f17-11ea-8a5b-81f20341d9f6.png">

New onboarding copy
![image](https://user-images.githubusercontent.com/6787950/79360569-7e1e1780-7f1a-11ea-9f7e-66013b2a83c3.png)

