### PR TITLE
Improve/send card

### DIFF
--- a/components/Onboarding/Configure/ImportMnemonic/__snapshots__/index.test.js.snap
+++ b/components/Onboarding/Configure/ImportMnemonic/__snapshots__/index.test.js.snap
@@ -262,6 +262,7 @@ exports[`Import seed phrase configuration it renders correctly 1`] = `
   background: #d1ddfa;
   padding-left: 16px;
   padding-right: 16px;
+  margin-top: 16px;
   width: 480px;
   display: inline-block;
   height: 64px;

--- a/components/Onboarding/Configure/ImportMnemonic/__snapshots__/index.test.js.snap
+++ b/components/Onboarding/Configure/ImportMnemonic/__snapshots__/index.test.js.snap
@@ -105,7 +105,6 @@ exports[`Import seed phrase configuration it renders correctly 1`] = `
 .c14 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -142,7 +141,9 @@ exports[`Import seed phrase configuration it renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c19 {
@@ -283,7 +284,6 @@ exports[`Import seed phrase configuration it renders correctly 1`] = `
 .c13 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
@@ -447,7 +447,6 @@ exports[`Import seed phrase configuration it renders correctly 1`] = `
             <div
               class="c17"
               display="flex"
-              width="100%"
             >
               <input
                 class="c18"

--- a/components/Onboarding/Configure/ImportPrivateKey/__snapshots__/index.test.js.snap
+++ b/components/Onboarding/Configure/ImportPrivateKey/__snapshots__/index.test.js.snap
@@ -95,7 +95,6 @@ exports[`Import private key configuration it renders correctly 1`] = `
 .c12 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -132,7 +131,9 @@ exports[`Import private key configuration it renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c17 {
@@ -270,7 +271,6 @@ exports[`Import private key configuration it renders correctly 1`] = `
 .c11 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
@@ -394,7 +394,6 @@ exports[`Import private key configuration it renders correctly 1`] = `
             <div
               class="c15"
               display="flex"
-              width="100%"
             >
               <input
                 class="c16"

--- a/components/Shared/AccountCard/__snapshots__/index.test.js.snap
+++ b/components/Shared/AccountCard/__snapshots__/index.test.js.snap
@@ -166,6 +166,7 @@ exports[`AccountCard renders the card 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
+  overflow: hidden;
   margin: 0;
 }
 
@@ -295,6 +296,7 @@ exports[`AccountCard renders the card 1`] = `
         font-family="RT-Alias-Grotesk"
         font-size="5"
         font-weight="1"
+        overflow="hidden"
       >
         t0123 ... 6789
       </h2>
@@ -503,6 +505,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
+  overflow: hidden;
   margin: 0;
 }
 
@@ -632,6 +635,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
         font-family="RT-Alias-Grotesk"
         font-size="5"
         font-weight="1"
+        overflow="hidden"
       >
         t0123 ... 6789
       </h2>

--- a/components/Shared/Input/BaseInput.js
+++ b/components/Shared/Input/BaseInput.js
@@ -8,6 +8,11 @@ import {
   typography
 } from 'styled-system'
 
+import {
+  inputBackgroundColor,
+  inputBackgroundColorHover
+} from './inputBackgroundColors'
+
 export default styled.input.attrs(props => ({
   display: 'inline-block',
   height: props.height || 7,
@@ -25,20 +30,10 @@ export default styled.input.attrs(props => ({
   font-size: ${props => props.theme.fontSizes[2]};
   text-align: right;
   cursor: text;
-  background: ${props => {
-    if (props.valid) return props.theme.colors.input.background.valid
-    if (props.error) return props.theme.colors.input.background.invalid
-    if (props.disabled) return props.theme.colors.input.background.disabled
-    return props.theme.colors.input.background.base
-  }};
+  background: ${props => inputBackgroundColor(props)};
 
   &:hover {
-    background: ${props => {
-      if (props.valid) return props.theme.colors.input.background.valid
-      if (props.error) return props.theme.colors.input.background.invalid
-      if (props.disabled) return props.theme.colors.core.transparent
-      return props.theme.colors.input.background.active
-    }};
+    background: ${props => inputBackgroundColorHover(props)};
     cursor: ${props => (props.disabled ? 'initial' : 'text')};
   }
 

--- a/components/Shared/Input/Funds.jsx
+++ b/components/Shared/Input/Funds.jsx
@@ -203,7 +203,7 @@ const Funds = forwardRef(
               fontSize={5}
               fontFamily='sansSerif'
               paddingBottom='4px'
-              zIndex='999'
+              zIndex='2'
             >
               {'\u003D'}
             </Box>
@@ -230,6 +230,7 @@ const Funds = forwardRef(
             <DenomTag
               top='0px'
               left='0px'
+              borderTopRightRadius={2}
               valid={valid && !!formatFilValue(filAmount)}
               disabled={disabled}
             >
@@ -267,6 +268,7 @@ const Funds = forwardRef(
               left='0px'
               valid={valid && !!formatFiatValue(fiatAmount)}
               disabled={disabled || converterError}
+              borderBottomRightRadius={2}
             >
               USD
             </DenomTag>

--- a/components/Shared/Input/Funds.jsx
+++ b/components/Shared/Input/Funds.jsx
@@ -226,6 +226,7 @@ const Funds = forwardRef(
               step={new FilecoinNumber('1', 'attofil').toFil()}
               disabled={disabled}
               valid={valid && !!formatFilValue(filAmount)}
+              {...props}
             />
             <DenomTag
               top='0px'
@@ -261,13 +262,13 @@ const Funds = forwardRef(
               step={new FilecoinNumber('1', 'attofil').toFil()}
               min='0'
               valid={valid && !!formatFiatValue(fiatAmount)}
-              disabled={disabled || converterError}
+              disabled={!!(disabled || converterError)}
             />
             <DenomTag
               top='0px'
               left='0px'
               valid={valid && !!formatFiatValue(fiatAmount)}
-              disabled={disabled || converterError}
+              disabled={!!(disabled || converterError)}
               borderBottomRightRadius={2}
             >
               USD

--- a/components/Shared/Input/Funds.jsx
+++ b/components/Shared/Input/Funds.jsx
@@ -226,15 +226,12 @@ const Funds = forwardRef(
               step={new FilecoinNumber('1', 'attofil').toFil()}
               disabled={disabled}
               valid={valid && !!formatFilValue(filAmount)}
-              {...props}
             />
             <DenomTag
               top='0px'
               left='0px'
-              borderTopRightRadius={2}
-              backgroundColor={
-                valid ? 'input.background.valid' : 'input.background.base'
-              }
+              valid={valid && !!formatFilValue(filAmount)}
+              disabled={disabled}
             >
               FIL
             </DenomTag>
@@ -243,9 +240,6 @@ const Funds = forwardRef(
             position='relative'
             display='flex'
             height='80px'
-            borderTop={1}
-            borderColor='background.screen'
-            bg='input.background.base'
             borderRadius={2}
           >
             <RawNumberInput
@@ -271,11 +265,8 @@ const Funds = forwardRef(
             <DenomTag
               top='0px'
               left='0px'
-              borderBottomRightRadius={2}
-              backgroundColor={
-                valid ? 'input.background.valid' : 'input.background.base'
-              }
-              borderBottomLeftRadius='4px'
+              valid={valid && !!formatFiatValue(fiatAmount)}
+              disabled={disabled || converterError}
             >
               USD
             </DenomTag>

--- a/components/Shared/Input/Funds.jsx
+++ b/components/Shared/Input/Funds.jsx
@@ -169,9 +169,11 @@ const Funds = forwardRef(
           color='input.border'
           bg={error && 'input.background.invalid'}
           px={2}
+          mr={2}
+          borderRadius={2}
         >
           {error ? (
-            <Text color='core.nearblack' textAlign='left'>
+            <Text color='core.nearblack' textAlign='center'>
               {error}
             </Text>
           ) : (
@@ -179,7 +181,15 @@ const Funds = forwardRef(
           )}
         </Box>
         <Box display='inline-block' width='100%'>
-          <Box position='relative' display='flex' height='80px' width='100%'>
+          <Box
+            position='relative'
+            display='flex'
+            height='80px'
+            width='100%'
+            borderBottom={1}
+            borderColor='background.screen'
+            borderTopLeftRadius={2}
+          >
             <Box
               position='absolute'
               left='-24px'
@@ -208,6 +218,7 @@ const Funds = forwardRef(
               }}
               height='100%'
               fontSize={5}
+              borderTopLeftRadius={2}
               onChange={onFilChange}
               value={formatFilValue(filAmount)}
               placeholder='0'
@@ -220,6 +231,7 @@ const Funds = forwardRef(
             <DenomTag
               top='0px'
               left='0px'
+              borderTopRightRadius={2}
               backgroundColor={
                 valid ? 'input.background.valid' : 'input.background.base'
               }
@@ -234,6 +246,7 @@ const Funds = forwardRef(
             borderTop={1}
             borderColor='background.screen'
             bg='input.background.base'
+            borderRadius={2}
           >
             <RawNumberInput
               onFocus={() => {
@@ -245,6 +258,7 @@ const Funds = forwardRef(
               }}
               height='100%'
               fontSize={5}
+              borderBottomLeftRadius={2}
               onChange={onFiatChange}
               value={formatFiatValue(fiatAmount)}
               placeholder={converterError ? 'Error fetching amount' : '0'}
@@ -257,9 +271,11 @@ const Funds = forwardRef(
             <DenomTag
               top='0px'
               left='0px'
+              borderBottomRightRadius={2}
               backgroundColor={
                 valid ? 'input.background.valid' : 'input.background.base'
               }
+              borderBottomLeftRadius='4px'
             >
               USD
             </DenomTag>

--- a/components/Shared/Input/Mnemonic.jsx
+++ b/components/Shared/Input/Mnemonic.jsx
@@ -52,6 +52,7 @@ const Mnemonic = forwardRef(
           </Box>
 
           <TextInput
+            mt={3}
             backgroundRadius={6}
             onBlur={() => validate(value)}
             onFocus={() => {

--- a/components/Shared/Input/Number.jsx
+++ b/components/Shared/Input/Number.jsx
@@ -17,9 +17,6 @@ export const DenomTag = styled(Box).attrs(props => ({
   fontSize: 3,
   minWidth: 7,
   color: 'core.primary',
-  // DELETE THIS COMMENT ONCE THESE ARE CLEANEDUP
-  borderBottomLeftRadius: '4px',
-  borderBottomRightRadius: 2,
   ...props
 }))`
   text-align: center;
@@ -48,12 +45,10 @@ export const NumberInput = forwardRef(
       error,
       setError,
       valid,
-      fontSize,
-      border,
-      color,
-      borderTop,
-      borderBottom,
-      backgroundColor,
+      // top, bottom, and middle are props to pass if you are stacking numbered inputs
+      top,
+      bottom,
+      middle,
       ...props
     },
     ref
@@ -76,9 +71,9 @@ export const NumberInput = forwardRef(
             display='flex'
             justifyContent='flex-end'
             width='100%'
-            color={color}
-            borderTop={borderTop}
-            borderBottom={borderBottom}
+            borderBottom='1px solid'
+            borderTop='1px solid'
+            color='background.screen'
           >
             <RawNumberInput
               type='number'
@@ -89,17 +84,18 @@ export const NumberInput = forwardRef(
               error={error}
               setError={setError}
               placeholder={placeholder}
-              fontSize={fontSize}
-              {...props}
+              borderBottomLeftRadius={bottom && !middle && 2}
+              borderTopLeftRadius={top && !middle && 2}
             />
             {denom && (
               <DenomTag
-                backgroundColor={backgroundColor}
                 height='64px'
                 top='0px'
                 left='0px'
                 valid={valid}
                 disabled={disabled}
+                borderTopRightRadius={top && !middle && 2}
+                borderBottomRightRadius={bottom && !middle && 2}
               >
                 {denom}
               </DenomTag>
@@ -119,13 +115,9 @@ NumberInput.propTypes = {
   disabled: bool,
   error: string,
   valid: bool,
-  fontSize: number,
-  color: string,
-  border: string,
-  borderColor: string,
-  borderTop: string,
-  borderBottom: string,
-  backgroundColor: string,
+  top: bool,
+  bottom: bool,
+  middle: bool,
   denom: string
 }
 
@@ -134,5 +126,7 @@ NumberInput.defaultProps = {
   disabled: false,
   onChange: () => {},
   label: '',
-  fontSize: 2
+  top: true,
+  bottom: true,
+  middle: false
 }

--- a/components/Shared/Input/Number.jsx
+++ b/components/Shared/Input/Number.jsx
@@ -15,7 +15,7 @@ export const DenomTag = styled(Box).attrs(props => ({
   fontSize: 3,
   minWidth: 7,
   color: 'core.primary',
-  backgroundColor: 'input.background.base',
+  backgroundColor: props.backgroundColor || 'input.background.base',
   ...props
 }))`
   text-align: center;
@@ -61,6 +61,7 @@ export const NumberInput = forwardRef(
       color,
       borderTop,
       borderBottom,
+      backgroundColor,
       denomBorderTopLeftRadius,
       denomBorderBottomLeftRadius,
       denomBorderTopRightRadius,
@@ -104,6 +105,7 @@ export const NumberInput = forwardRef(
             />
             {denom && (
               <DenomTag
+                backgroundColor={backgroundColor}
                 borderTopLeftRadius={denomBorderTopLeftRadius}
                 borderBottomLeftRadius={denomBorderBottomLeftRadius}
                 borderTopRightRadius={denomBorderTopRightRadius}
@@ -138,6 +140,7 @@ NumberInput.propTypes = {
   borderColor: string,
   borderTop: string,
   borderBottom: string,
+  backgroundColor: string,
   denom: string,
   denomBorderTopLeftRadius: number,
   denomBorderBottomLeftRadius: number,

--- a/components/Shared/Input/Number.jsx
+++ b/components/Shared/Input/Number.jsx
@@ -57,6 +57,14 @@ export const NumberInput = forwardRef(
       setError,
       valid,
       fontSize,
+      border,
+      color,
+      borderTop,
+      borderBottom,
+      denomBorderTopLeftRadius,
+      denomBorderBottomLeftRadius,
+      denomBorderTopRightRadius,
+      denomBorderBottomRightRadius,
       ...props
     },
     ref
@@ -79,6 +87,9 @@ export const NumberInput = forwardRef(
             display='flex'
             justifyContent='flex-end'
             width='100%'
+            color={color}
+            borderTop={borderTop}
+            borderBottom={borderBottom}
           >
             <RawNumberInput
               type='number'
@@ -93,6 +104,10 @@ export const NumberInput = forwardRef(
             />
             {denom && (
               <DenomTag
+                borderTopLeftRadius={denomBorderTopLeftRadius}
+                borderBottomLeftRadius={denomBorderBottomLeftRadius}
+                borderTopRightRadius={denomBorderTopRightRadius}
+                borderBottomRightRadius={denomBorderBottomRightRadius}
                 height='64px'
                 css={`
                   top: 0px;
@@ -118,7 +133,16 @@ NumberInput.propTypes = {
   error: string,
   valid: bool,
   fontSize: number,
-  denom: string
+  color: string,
+  border: string,
+  borderColor: string,
+  borderTop: string,
+  borderBottom: string,
+  denom: string,
+  denomBorderTopLeftRadius: number,
+  denomBorderBottomLeftRadius: number,
+  denomBorderTopRightRadius: number,
+  denomBorderBottomRightRadius: number
 }
 
 NumberInput.defaultProps = {

--- a/components/Shared/Input/Number.jsx
+++ b/components/Shared/Input/Number.jsx
@@ -6,6 +6,8 @@ import InputWrapper from './InputWrapper'
 import Box from '../Box'
 import { Label } from '../Typography'
 
+import { inputBackgroundColor } from './inputBackgroundColors'
+
 export const DenomTag = styled(Box).attrs(props => ({
   display: 'flex',
   height: '100%',
@@ -15,33 +17,22 @@ export const DenomTag = styled(Box).attrs(props => ({
   fontSize: 3,
   minWidth: 7,
   color: 'core.primary',
-  backgroundColor: props.backgroundColor || 'input.background.base',
+  // DELETE THIS COMMENT ONCE THESE ARE CLEANEDUP
+  borderBottomLeftRadius: '4px',
+  borderBottomRightRadius: 2,
   ...props
 }))`
   text-align: center;
   position: relative;
-  background: ${props => {
-    if (props.valid) return props.theme.colors.input.background.valid
-    if (props.error) return props.theme.colors.input.background.invalid
-    if (props.disabled) return props.theme.colors.input.background.disabled
-    return props.theme.colors.input.background.base
-  }};
+  background: ${props => inputBackgroundColor(props)};
 `
 
-export const RawNumberInput = styled(BaseInput).attrs(props => ({
-  ...props
-}))`
+export const RawNumberInput = styled(BaseInput)`
   ::-webkit-outer-spin-button,
   ::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
-  background: ${props => {
-    if (props.valid) return props.theme.colors.input.background.valid
-    if (props.error) return props.theme.colors.input.background.invalid
-    if (props.disabled) return props.theme.colors.input.background.disabled
-    return props.theme.colors.input.background.base
-  }};
   -moz-appearance: textfield;
 `
 
@@ -49,6 +40,7 @@ export const NumberInput = forwardRef(
   (
     {
       denom,
+      disabled,
       onChange,
       value,
       placeholder,
@@ -62,10 +54,6 @@ export const NumberInput = forwardRef(
       borderTop,
       borderBottom,
       backgroundColor,
-      denomBorderTopLeftRadius,
-      denomBorderBottomLeftRadius,
-      denomBorderTopRightRadius,
-      denomBorderBottomRightRadius,
       ...props
     },
     ref
@@ -97,6 +85,7 @@ export const NumberInput = forwardRef(
               onChange={onChange}
               value={value}
               valid={valid}
+              disabled={disabled}
               error={error}
               setError={setError}
               placeholder={placeholder}
@@ -106,15 +95,11 @@ export const NumberInput = forwardRef(
             {denom && (
               <DenomTag
                 backgroundColor={backgroundColor}
-                borderTopLeftRadius={denomBorderTopLeftRadius}
-                borderBottomLeftRadius={denomBorderBottomLeftRadius}
-                borderTopRightRadius={denomBorderTopRightRadius}
-                borderBottomRightRadius={denomBorderBottomRightRadius}
                 height='64px'
-                css={`
-                  top: 0px;
-                  left: 0px;
-                `}
+                top='0px'
+                left='0px'
+                valid={valid}
+                disabled={disabled}
               >
                 {denom}
               </DenomTag>
@@ -141,11 +126,7 @@ NumberInput.propTypes = {
   borderTop: string,
   borderBottom: string,
   backgroundColor: string,
-  denom: string,
-  denomBorderTopLeftRadius: number,
-  denomBorderBottomLeftRadius: number,
-  denomBorderTopRightRadius: number,
-  denomBorderBottomRightRadius: number
+  denom: string
 }
 
 NumberInput.defaultProps = {

--- a/components/Shared/Input/Text.jsx
+++ b/components/Shared/Input/Text.jsx
@@ -16,7 +16,7 @@ const TextInput = ({
   ...props
 }) => (
   <>
-    <InputWrapper mt={3}>
+    <InputWrapper>
       <Box display='flex' alignItems='center' pl={2}>
         {label && (
           <Box
@@ -28,7 +28,7 @@ const TextInput = ({
             <Label color='core.nearblack'>{label}</Label>
           </Box>
         )}
-        <Box position='relative' display='flex' width='100%'>
+        <Box position='relative' display='flex' flex='1'>
           <BaseInput
             px={3}
             borderRadius={2}

--- a/components/Shared/Input/Text.jsx
+++ b/components/Shared/Input/Text.jsx
@@ -17,7 +17,7 @@ const TextInput = ({
 }) => (
   <>
     <InputWrapper>
-      <Box display='flex' alignItems='center' pl={2}>
+      <Box display='flex' alignItems='center'>
         {label && (
           <Box
             display='flex'

--- a/components/Shared/Input/Text.jsx
+++ b/components/Shared/Input/Text.jsx
@@ -38,13 +38,7 @@ const TextInput = ({
             {...props}
           />
           {denom && (
-            <DenomTag
-              height={7}
-              css={`
-                background-color: ${props =>
-                  props.theme.colors.core.transparent};
-              `}
-            >
+            <DenomTag height={7} backgroundColor='core.transparent'>
               {denom}
             </DenomTag>
           )}

--- a/components/Shared/Input/Text.jsx
+++ b/components/Shared/Input/Text.jsx
@@ -38,7 +38,13 @@ const TextInput = ({
             {...props}
           />
           {denom && (
-            <DenomTag backgroundColor='core.transparent' height={7}>
+            <DenomTag
+              height={7}
+              css={`
+                background-color: ${props =>
+                  props.theme.colors.core.transparent};
+              `}
+            >
               {denom}
             </DenomTag>
           )}

--- a/components/Shared/Input/__snapshots__/Funds.test.js.snap
+++ b/components/Shared/Input/__snapshots__/Funds.test.js.snap
@@ -17,8 +17,10 @@ exports[`Funds input changing values it calls the value change callback when the
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -52,6 +54,9 @@ exports[`Funds input changing values it calls the value change callback when the
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -94,6 +99,7 @@ exports[`Funds input changing values it calls the value change callback when the
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -116,6 +122,38 @@ exports[`Funds input changing values it calls the value change callback when the
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -159,6 +197,7 @@ exports[`Funds input changing values it calls the value change callback when the
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -178,6 +217,49 @@ exports[`Funds input changing values it calls the value change callback when the
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -253,7 +335,7 @@ exports[`Funds input changing values it calls the value change callback when the
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -265,7 +347,7 @@ exports[`Funds input changing values it calls the value change callback when the
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -295,8 +377,10 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -330,6 +414,9 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -372,6 +459,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -394,6 +482,38 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -437,6 +557,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -456,6 +577,49 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -531,7 +695,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -543,7 +707,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -564,7 +728,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   name="amount"
 >
   <div
-    class="Box-tuskkk-0 bLRFGJ"
+    class="Box-tuskkk-0 cWLblP"
     color="input.border"
     display="flex"
     width="100%"
@@ -585,7 +749,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
     width="100%"
   >
     <div
-      class="Box-tuskkk-0 ewkQwq"
+      class="Box-tuskkk-0 dLbmTz"
       display="flex"
       height="80px"
       width="100%"
@@ -600,7 +764,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -613,7 +777,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -623,12 +787,12 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 swQTS"
+      class="Box-tuskkk-0 TPMPG"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -640,7 +804,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -670,8 +834,10 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -705,6 +871,9 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -747,6 +916,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -769,6 +939,38 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -812,6 +1014,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -831,6 +1034,49 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -906,7 +1152,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -918,7 +1164,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -948,8 +1194,10 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -983,6 +1231,9 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1025,6 +1276,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1047,6 +1299,38 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -1090,6 +1374,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -1109,6 +1394,49 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -1184,7 +1512,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1196,7 +1524,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1217,7 +1545,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   name="amount"
 >
   <div
-    class="Box-tuskkk-0 bLRFGJ"
+    class="Box-tuskkk-0 cWLblP"
     color="input.border"
     display="flex"
     width="100%"
@@ -1238,7 +1566,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
     width="100%"
   >
     <div
-      class="Box-tuskkk-0 ewkQwq"
+      class="Box-tuskkk-0 dLbmTz"
       display="flex"
       height="80px"
       width="100%"
@@ -1253,7 +1581,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1266,7 +1594,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1276,12 +1604,12 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 swQTS"
+      class="Box-tuskkk-0 TPMPG"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1293,7 +1621,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1323,8 +1651,10 @@ exports[`Funds input changing values it sets the right fiat amount when the user
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1358,6 +1688,9 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1400,6 +1733,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1422,6 +1756,38 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -1465,6 +1831,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -1484,6 +1851,49 @@ exports[`Funds input changing values it sets the right fiat amount when the user
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -1559,7 +1969,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1571,7 +1981,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1601,8 +2011,10 @@ exports[`Funds input changing values it sets the right fiat amount when the user
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1636,6 +2048,9 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1678,6 +2093,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1700,6 +2116,38 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -1743,6 +2191,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -1762,6 +2211,49 @@ exports[`Funds input changing values it sets the right fiat amount when the user
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -1837,7 +2329,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1849,7 +2341,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1870,7 +2362,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   name="amount"
 >
   <div
-    class="Box-tuskkk-0 bLRFGJ"
+    class="Box-tuskkk-0 cWLblP"
     color="input.border"
     display="flex"
     width="100%"
@@ -1891,7 +2383,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
     width="100%"
   >
     <div
-      class="Box-tuskkk-0 ewkQwq"
+      class="Box-tuskkk-0 dLbmTz"
       display="flex"
       height="80px"
       width="100%"
@@ -1906,7 +2398,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1919,7 +2411,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1929,12 +2421,12 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 swQTS"
+      class="Box-tuskkk-0 TPMPG"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1946,7 +2438,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1976,8 +2468,10 @@ exports[`Funds input changing values it sets the right fiat amount when the user
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2011,6 +2505,9 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2053,6 +2550,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2075,6 +2573,38 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -2118,6 +2648,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -2137,6 +2668,49 @@ exports[`Funds input changing values it sets the right fiat amount when the user
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -2212,7 +2786,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2224,7 +2798,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2245,7 +2819,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   name="amount"
 >
   <div
-    class="Box-tuskkk-0 bLRFGJ"
+    class="Box-tuskkk-0 cWLblP"
     color="input.border"
     display="flex"
     width="100%"
@@ -2266,7 +2840,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
     width="100%"
   >
     <div
-      class="Box-tuskkk-0 ewkQwq"
+      class="Box-tuskkk-0 dLbmTz"
       display="flex"
       height="80px"
       width="100%"
@@ -2281,7 +2855,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2294,7 +2868,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2304,12 +2878,12 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 swQTS"
+      class="Box-tuskkk-0 TPMPG"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 dcbztZ"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2321,7 +2895,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 hHRmjy"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2351,8 +2925,10 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2386,6 +2962,9 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2428,6 +3007,7 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2450,6 +3030,38 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -2493,6 +3105,7 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -2512,6 +3125,49 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -2587,7 +3243,7 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2599,7 +3255,7 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2629,8 +3285,10 @@ exports[`Funds input it renders correctly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2664,6 +3322,9 @@ exports[`Funds input it renders correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2706,6 +3367,7 @@ exports[`Funds input it renders correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2728,6 +3390,38 @@ exports[`Funds input it renders correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #85e0cb;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #85e0cb;
@@ -2771,6 +3465,7 @@ exports[`Funds input it renders correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #85e0cb;
@@ -2790,6 +3485,49 @@ exports[`Funds input it renders correctly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #85e0cb;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #85e0cb;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #85e0cb;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #85e0cb;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -2865,7 +3603,7 @@ exports[`Funds input it renders correctly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2877,7 +3615,7 @@ exports[`Funds input it renders correctly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2907,8 +3645,10 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2942,6 +3682,9 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2984,6 +3727,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3006,6 +3750,38 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -3048,6 +3824,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   -moz-appearance: textfield;
@@ -3066,6 +3843,47 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: transparent;
+  cursor: initial;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -3142,7 +3960,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         disabled=""
         display="inline-block"
         font-size="5"
@@ -3155,7 +3973,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -3185,8 +4003,10 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3220,6 +4040,9 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3262,6 +4085,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3284,6 +4108,38 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #85e0cb;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #85e0cb;
@@ -3327,6 +4183,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #85e0cb;
@@ -3346,6 +4203,49 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #85e0cb;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #85e0cb;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #85e0cb;
+  cursor: initial;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #85e0cb;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -3422,7 +4322,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         disabled=""
         display="inline-block"
         font-size="5"
@@ -3435,7 +4335,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -3465,8 +4365,10 @@ exports[`Funds input it renders disabled state correctly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3500,6 +4402,9 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3542,6 +4447,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3564,6 +4470,38 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -3606,6 +4544,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   -moz-appearance: textfield;
@@ -3624,6 +4563,47 @@ exports[`Funds input it renders disabled state correctly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: transparent;
+  cursor: initial;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -3700,7 +4680,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         disabled=""
         display="inline-block"
         font-size="5"
@@ -3713,7 +4693,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -3743,8 +4723,10 @@ exports[`Funds input it renders error states properly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   background-color: #FC6D6F;
   display: -webkit-box;
@@ -3779,6 +4761,9 @@ exports[`Funds input it renders error states properly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3821,6 +4806,7 @@ exports[`Funds input it renders error states properly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3835,7 +4821,7 @@ exports[`Funds input it renders error states properly 1`] = `
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
-  text-align: left;
+  text-align: center;
 }
 
 .c7 {
@@ -3843,6 +4829,38 @@ exports[`Funds input it renders error states properly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -3886,6 +4904,7 @@ exports[`Funds input it renders error states properly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -3905,6 +4924,49 @@ exports[`Funds input it renders error states properly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -3980,7 +5042,7 @@ exports[`Funds input it renders error states properly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -3992,7 +5054,7 @@ exports[`Funds input it renders error states properly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -4022,8 +5084,10 @@ exports[`Funds input it renders invalid state correctly 1`] = `
 .c1 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4057,6 +5121,9 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4099,6 +5166,7 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4121,6 +5189,38 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -4164,6 +5264,7 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -4183,6 +5284,49 @@ exports[`Funds input it renders invalid state correctly 1`] = `
 
 .c6::-webkit-outer-spin-button,
 .c6::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c9 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c9:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c9:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c9::-webkit-outer-spin-button,
+.c9::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -4258,7 +5402,7 @@ exports[`Funds input it renders invalid state correctly 1`] = `
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 c6"
+        class="BaseInput-u1913i-0 c9"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -4270,7 +5414,7 @@ exports[`Funds input it renders invalid state correctly 1`] = `
         width="100%"
       />
       <div
-        class="c7"
+        class="c10"
         color="core.primary"
         display="flex"
         font-size="3"

--- a/components/Shared/Input/__snapshots__/Funds.test.js.snap
+++ b/components/Shared/Input/__snapshots__/Funds.test.js.snap
@@ -71,7 +71,7 @@ exports[`Funds input changing values it calls the value change callback when the
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -97,10 +97,7 @@ exports[`Funds input changing values it calls the value change callback when the
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -125,7 +122,6 @@ exports[`Funds input changing values it calls the value change callback when the
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -153,10 +149,8 @@ exports[`Funds input changing values it calls the value change callback when the
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -200,7 +194,6 @@ exports[`Funds input changing values it calls the value change callback when the
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -243,7 +236,6 @@ exports[`Funds input changing values it calls the value change callback when the
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -431,7 +423,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -457,10 +449,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -485,7 +474,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -513,10 +501,8 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -560,7 +546,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -603,7 +588,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -755,7 +739,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       width="100%"
     >
       <div
-        class="Box-tuskkk-0 eobIRr"
+        class="Box-tuskkk-0 cyvysm"
         display="flex"
         font-family="sansSerif"
         font-size="5"
@@ -764,7 +748,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 dSlJKE"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -777,7 +761,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 dWdluT"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -787,12 +771,12 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 TPMPG"
+      class="Box-tuskkk-0 dRjsN"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 hvfnSA"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -804,7 +788,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 zUaor"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -888,7 +872,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -914,10 +898,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -942,7 +923,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -970,10 +950,8 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1017,7 +995,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -1060,7 +1037,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -1248,7 +1224,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -1274,10 +1250,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1302,7 +1275,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1330,10 +1302,8 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1377,7 +1347,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -1420,7 +1389,6 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -1572,7 +1540,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       width="100%"
     >
       <div
-        class="Box-tuskkk-0 eobIRr"
+        class="Box-tuskkk-0 cyvysm"
         display="flex"
         font-family="sansSerif"
         font-size="5"
@@ -1581,7 +1549,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 dSlJKE"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1594,7 +1562,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 dWdluT"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1604,12 +1572,12 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 TPMPG"
+      class="Box-tuskkk-0 dRjsN"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 hvfnSA"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -1621,7 +1589,7 @@ exports[`Funds input changing values it sets the right FIL amount when the user 
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 zUaor"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1705,7 +1673,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -1731,10 +1699,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1759,7 +1724,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1787,10 +1751,8 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1834,7 +1796,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -1877,7 +1838,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -2065,7 +2025,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -2091,10 +2051,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2119,7 +2076,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2147,10 +2103,8 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2194,7 +2148,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -2237,7 +2190,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -2389,7 +2341,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       width="100%"
     >
       <div
-        class="Box-tuskkk-0 eobIRr"
+        class="Box-tuskkk-0 cyvysm"
         display="flex"
         font-family="sansSerif"
         font-size="5"
@@ -2398,7 +2350,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 dSlJKE"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2411,7 +2363,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 dWdluT"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2421,12 +2373,12 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 TPMPG"
+      class="Box-tuskkk-0 dRjsN"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 hvfnSA"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2438,7 +2390,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 zUaor"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2522,7 +2474,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -2548,10 +2500,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2576,7 +2525,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2604,10 +2552,8 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2651,7 +2597,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -2694,7 +2639,6 @@ exports[`Funds input changing values it sets the right fiat amount when the user
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -2846,7 +2790,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       width="100%"
     >
       <div
-        class="Box-tuskkk-0 eobIRr"
+        class="Box-tuskkk-0 cyvysm"
         display="flex"
         font-family="sansSerif"
         font-size="5"
@@ -2855,7 +2799,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         =
       </div>
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 fsFcnh"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 dSlJKE"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2868,7 +2812,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 bUEmnF"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 dWdluT"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2878,12 +2822,12 @@ exports[`Funds input changing values it sets the right fiat amount when the user
       </div>
     </div>
     <div
-      class="Box-tuskkk-0 TPMPG"
+      class="Box-tuskkk-0 dRjsN"
       display="flex"
       height="80px"
     >
       <input
-        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-2 edVSdt"
+        class="BaseInput-u1913i-0 Number__RawNumberInput-a1xk82-1 hvfnSA"
         display="inline-block"
         font-size="5"
         height="100%"
@@ -2895,7 +2839,7 @@ exports[`Funds input changing values it sets the right fiat amount when the user
         width="100%"
       />
       <div
-        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 ePJWPJ"
+        class="Box-tuskkk-0 Number__DenomTag-a1xk82-0 zUaor"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2979,7 +2923,7 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -3005,10 +2949,7 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3033,7 +2974,6 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3061,10 +3001,8 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3108,7 +3046,6 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -3151,7 +3088,6 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -3339,7 +3275,7 @@ exports[`Funds input it renders correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -3365,10 +3301,7 @@ exports[`Funds input it renders correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3393,7 +3326,6 @@ exports[`Funds input it renders correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3412,7 +3344,7 @@ exports[`Funds input it renders correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: #85e0cb;
 }
 
 .c10 {
@@ -3421,10 +3353,8 @@ exports[`Funds input it renders correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3443,7 +3373,7 @@ exports[`Funds input it renders correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: #85e0cb;
 }
 
 .c6 {
@@ -3468,7 +3398,6 @@ exports[`Funds input it renders correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
@@ -3511,7 +3440,6 @@ exports[`Funds input it renders correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
@@ -3699,7 +3627,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -3725,10 +3653,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3753,7 +3678,6 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3772,7 +3696,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c10 {
@@ -3781,10 +3705,8 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3803,7 +3725,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c6 {
@@ -3820,6 +3742,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -3861,6 +3784,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -3947,6 +3871,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
       <div
         class="c7"
         color="core.primary"
+        disabled=""
         display="flex"
         font-size="3"
         height="100%"
@@ -3975,6 +3900,7 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
       <div
         class="c10"
         color="core.primary"
+        disabled=""
         display="flex"
         font-size="3"
         height="100%"
@@ -4057,7 +3983,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -4083,10 +4009,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4111,7 +4034,6 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4130,7 +4052,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c10 {
@@ -4139,10 +4061,8 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4161,7 +4081,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c6 {
@@ -4178,7 +4098,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background: #85e0cb;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -4186,12 +4106,11 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
 .c6:hover {
-  background: #85e0cb;
+  background: transparent;
   cursor: initial;
 }
 
@@ -4221,7 +4140,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background: #85e0cb;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -4229,12 +4148,11 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
 .c9:hover {
-  background: #85e0cb;
+  background: transparent;
   cursor: initial;
 }
 
@@ -4309,6 +4227,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
       <div
         class="c7"
         color="core.primary"
+        disabled=""
         display="flex"
         font-size="3"
         height="100%"
@@ -4337,6 +4256,7 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
       <div
         class="c10"
         color="core.primary"
+        disabled=""
         display="flex"
         font-size="3"
         height="100%"
@@ -4419,7 +4339,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -4445,10 +4365,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4473,7 +4390,6 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4492,7 +4408,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c10 {
@@ -4501,10 +4417,8 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4523,7 +4437,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c6 {
@@ -4540,6 +4454,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -4581,6 +4496,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -4667,6 +4583,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
       <div
         class="c7"
         color="core.primary"
+        disabled=""
         display="flex"
         font-size="3"
         height="100%"
@@ -4695,6 +4612,7 @@ exports[`Funds input it renders disabled state correctly 1`] = `
       <div
         class="c10"
         color="core.primary"
+        disabled=""
         display="flex"
         font-size="3"
         height="100%"
@@ -4778,7 +4696,7 @@ exports[`Funds input it renders error states properly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -4804,10 +4722,7 @@ exports[`Funds input it renders error states properly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4832,7 +4747,6 @@ exports[`Funds input it renders error states properly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4860,10 +4774,8 @@ exports[`Funds input it renders error states properly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4907,7 +4819,6 @@ exports[`Funds input it renders error states properly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -4950,7 +4861,6 @@ exports[`Funds input it renders error states properly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -5138,7 +5048,7 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -5164,10 +5074,7 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5192,7 +5099,6 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5220,10 +5126,8 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5267,7 +5171,6 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -5310,7 +5213,6 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 

--- a/components/Shared/Input/inputBackgroundColors.js
+++ b/components/Shared/Input/inputBackgroundColors.js
@@ -1,0 +1,18 @@
+export const inputBackgroundColorHover = props => {
+  if (props.disabled) return props.theme.colors.core.transparent
+  if (props.valid) return props.theme.colors.input.background.valid
+  if (props.error) return props.theme.colors.input.background.invalid
+  return props.theme.colors.input.background.active
+}
+
+export const inputBackgroundColor = props => {
+  if (props.disabled) return props.theme.colors.core.transparent
+  if (props.valid) return props.theme.colors.input.background.valid
+  if (props.error) return props.theme.colors.input.background.invalid
+  return (
+    props.backgroundColor ||
+    props.background ||
+    props.bg ||
+    props.theme.colors.input.background.base
+  )
+}

--- a/components/Wallet/Message/__snapshots__/index.test.js.snap
+++ b/components/Wallet/Message/__snapshots__/index.test.js.snap
@@ -3188,7 +3188,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -3214,10 +3214,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3413,6 +3410,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   padding-left: 16px;
   padding-right: 16px;
   margin-top: 8px;
@@ -3449,6 +3447,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   background-color: #EFF3FD;
   padding-left: 16px;
   padding-right: 16px;
@@ -3485,7 +3484,6 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3504,7 +3502,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c34 {
@@ -3513,10 +3511,8 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3535,7 +3531,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: transparent;
 }
 
 .c30 {
@@ -3552,6 +3548,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -3593,6 +3590,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
+  background: transparent;
   font-size: 2rem;
   height: 100%;
   display: inline-block;
@@ -3949,6 +3947,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
           <div
             class="c31"
             color="core.primary"
+            disabled=""
             display="flex"
             font-size="3"
             height="100%"
@@ -3977,6 +3976,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
           <div
             class="c34"
             color="core.primary"
+            disabled=""
             display="flex"
             font-size="3"
             height="100%"

--- a/components/Wallet/Message/__snapshots__/index.test.js.snap
+++ b/components/Wallet/Message/__snapshots__/index.test.js.snap
@@ -3077,7 +3077,6 @@ exports[`MessageHistory View it renders the message detail view after clicking o
 .c20 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3114,7 +3113,9 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c25 {
@@ -3133,8 +3134,10 @@ exports[`MessageHistory View it renders the message detail view after clicking o
 .c26 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3168,6 +3171,9 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3210,6 +3216,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3218,7 +3225,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   height: 80px;
 }
 
-.c34 {
+.c36 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
@@ -3241,7 +3248,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   justify-content: space-between;
 }
 
-.c36 {
+.c38 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -3255,7 +3262,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   text-align: right;
 }
 
-.c40 {
+.c42 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 48px;
@@ -3288,7 +3295,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   height: 24px;
 }
 
-.c35 {
+.c37 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -3296,7 +3303,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   margin: 0;
 }
 
-.c37 {
+.c39 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -3305,7 +3312,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   margin: 0;
 }
 
-.c39 {
+.c41 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -3361,7 +3368,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   margin: 0;
 }
 
-.c41 {
+.c43 {
   color: #999999;
   text-align: left;
   font-size: 1.125rem;
@@ -3371,7 +3378,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   margin: 4px;
 }
 
-.c42 {
+.c44 {
   color: #999999;
   text-align: left;
   font-size: 1.125rem;
@@ -3382,7 +3389,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   margin: 4px;
 }
 
-.c45 {
+.c47 {
   color: #5E26FF;
   text-align: left;
   font-size: 1.125rem;
@@ -3428,7 +3435,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   background: #bacbf7;
 }
 
-.c33 {
+.c35 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -3453,12 +3460,12 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   border-color: #999999;
 }
 
-.c33:hover {
+.c35:hover {
   background: transparent;
   cursor: initial;
 }
 
-.c33:focus {
+.c35:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
@@ -3467,7 +3474,6 @@ exports[`MessageHistory View it renders the message detail view after clicking o
 .c19 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
@@ -3476,6 +3482,38 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #d1ddfa;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c34 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -3518,6 +3556,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   -moz-appearance: textfield;
@@ -3540,7 +3579,48 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   margin: 0;
 }
 
-.c44 {
+.c33 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  -moz-appearance: textfield;
+}
+
+.c33:hover {
+  background: transparent;
+  cursor: initial;
+}
+
+.c33:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c33::-webkit-outer-spin-button,
+.c33::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c46 {
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: 0.18s ease-in-out;
@@ -3550,7 +3630,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 1.25rem;
 }
 
-.c44:hover {
+.c46:hover {
   border-bottom: 2px solid #5E26FF;
 }
 
@@ -3593,11 +3673,11 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   align-self: flex-end;
 }
 
-.c38 {
+.c40 {
   word-wrap: break-word;
 }
 
-.c43 {
+.c45 {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: no-wrap;
@@ -3760,7 +3840,6 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         <div
           class="c23"
           display="flex"
-          width="100%"
         >
           <input
             class="c24"
@@ -3799,7 +3878,6 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         <div
           class="c23"
           display="flex"
-          width="100%"
         >
           <input
             class="c24"
@@ -3884,7 +3962,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
           height="80px"
         >
           <input
-            class="c30"
+            class="c33"
             disabled=""
             display="inline-block"
             font-size="5"
@@ -3897,7 +3975,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
             width="100%"
           />
           <div
-            class="c31"
+            class="c34"
             color="core.primary"
             display="flex"
             font-size="3"
@@ -3932,10 +4010,9 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         <div
           class="c23"
           display="flex"
-          width="100%"
         >
           <input
-            class="c33"
+            class="c35"
             disabled=""
             display="inline-block"
             height="7"
@@ -3947,11 +4024,11 @@ exports[`MessageHistory View it renders the message detail view after clicking o
       </div>
     </div>
     <div
-      class="c34"
+      class="c36"
       display="flex"
     >
       <h2
-        class="c35"
+        class="c37"
         font-family="RT-Alias-Grotesk"
         font-size="4"
         font-weight="400"
@@ -3959,11 +4036,11 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         Total
       </h2>
       <div
-        class="c36"
+        class="c38"
         display="flex"
       >
         <h2
-          class="c37 c38"
+          class="c39 c40"
           color="core.primary"
           font-family="RT-Alias-Grotesk"
           font-size="5"
@@ -3974,7 +4051,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
           FIL
         </h2>
         <h2
-          class="c39"
+          class="c41"
           color="core.darkgray"
           font-family="RT-Alias-Grotesk"
           font-size="4"
@@ -3985,11 +4062,11 @@ exports[`MessageHistory View it renders the message detail view after clicking o
       </div>
     </div>
     <div
-      class="c40"
+      class="c42"
       display="flex"
     >
       <h4
-        class="c41"
+        class="c43"
         color="core.silver"
         font-family="RT-Alias-Grotesk"
         font-size="2"
@@ -3998,7 +4075,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         Message Hash
       </h4>
       <h4
-        class="c42 c43"
+        class="c44 c45"
         color="core.silver"
         font-family="RT-Alias-Grotesk"
         font-size="2"
@@ -4007,7 +4084,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         bafy2bzacea5463eugsz6f7dbwixzqxmwe2ouqeq6zukackb3xxotskdidqmjm
       </h4>
       <a
-        class="c44"
+        class="c46"
         color="core.primary"
         font-size="3"
         href="https://filscout.io/en/pc/message/bafy2bzacea5463eugsz6f7dbwixzqxmwe2ouqeq6zukackb3xxotskdidqmjm"
@@ -4015,7 +4092,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
         target="_blank"
       >
         <h4
-          class="c45"
+          class="c47"
           color="core.primary"
           font-family="RT-Alias-Grotesk"
           font-size="2"

--- a/components/Wallet/Send.js/GasCustomization.jsx
+++ b/components/Wallet/Send.js/GasCustomization.jsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import { FilecoinNumber } from '@openworklabs/filecoin-number'
 import { func, bool, string } from 'prop-types'
-import { Box, Label, Container, Input, StyledATag } from '../../Shared'
+import { Box, Label, Input, StyledATag } from '../../Shared'
 import { FILECOIN_NUMBER_PROP } from '../../../customPropTypes'
 
 // this is a weird hack to get tests to run in jest...
@@ -58,12 +58,10 @@ const GasCustomization = ({
           <Box>
             <Box mt={3}>
               <Input.Number
+                top
+                bottom={false}
                 mt={2}
                 m='0'
-                borderBottom='1px solid'
-                color='background.screen'
-                borderTopLeftRadius={2}
-                denomBorderTopRightRadius={2}
                 denom='AttoFil'
                 label='Gas Price'
                 value={gasPrice.toAttoFil()}
@@ -71,11 +69,9 @@ const GasCustomization = ({
               />
               <Box borderColor='background.screen'>
                 <NumberedInput
+                  bottom
+                  top={false}
                   m='0'
-                  borderTop='1px solid'
-                  color='background.screen'
-                  borderBottomLeftRadius={2}
-                  denomBorderBottomRightRadius={2}
                   denom='AttoFil'
                   label='Gas Limit'
                   value={gasLimit.toAttoFil()}

--- a/components/Wallet/Send.js/GasCustomization.jsx
+++ b/components/Wallet/Send.js/GasCustomization.jsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import { FilecoinNumber } from '@openworklabs/filecoin-number'
 import { func, bool, string } from 'prop-types'
-import { Box, Label, ContentContainer, Input, StyledATag } from '../../Shared'
+import { Box, Label, Container, Input, StyledATag } from '../../Shared'
 import { FILECOIN_NUMBER_PROP } from '../../../customPropTypes'
 
 // this is a weird hack to get tests to run in jest...
@@ -36,7 +36,7 @@ const GasCustomization = ({
   return (
     <>
       {show && (
-        <ContentContainer mt={2}>
+        <Box mt={2} p={3} borderTop={1} borderBottom={1} borderColor='silver'>
           <Box
             display='flex'
             justifyContent='space-between'
@@ -88,7 +88,7 @@ const GasCustomization = ({
               </Box>
             </Box>
           </Box>
-        </ContentContainer>
+        </Box>
       )}
     </>
   )

--- a/components/Wallet/Send.js/GasCustomization.jsx
+++ b/components/Wallet/Send.js/GasCustomization.jsx
@@ -55,27 +55,37 @@ const GasCustomization = ({
               What&rsquo;s this?
             </StyledATag>
           </Box>
-          <Box borderColor='input.border' mt={3}>
-            <Input.Number
-              mt={2}
-              m='0'
-              denom='AttoFil'
-              label='Gas Price'
-              value={gasPrice.toAttoFil()}
-              onChange={onGasPriceInputChange}
-            />
-            <Box borderColor='input.border'>
-              <NumberedInput
+          <Box>
+            <Box mt={3}>
+              <Input.Number
+                mt={2}
                 m='0'
+                borderBottom='1px solid'
+                color='background.screen'
+                borderTopLeftRadius={2}
+                denomBorderTopRightRadius={2}
                 denom='AttoFil'
-                label='Gas Limit'
-                value={gasLimit.toAttoFil()}
-                onChange={e =>
-                  setGasLimit(
-                    new FilecoinNumber(e.target.value || '0', 'attofil')
-                  )
-                }
+                label='Gas Price'
+                value={gasPrice.toAttoFil()}
+                onChange={onGasPriceInputChange}
               />
+              <Box borderColor='background.screen'>
+                <NumberedInput
+                  m='0'
+                  borderTop='1px solid'
+                  color='background.screen'
+                  borderBottomLeftRadius={2}
+                  denomBorderBottomRightRadius={2}
+                  denom='AttoFil'
+                  label='Gas Limit'
+                  value={gasLimit.toAttoFil()}
+                  onChange={e =>
+                    setGasLimit(
+                      new FilecoinNumber(e.target.value || '0', 'attofil')
+                    )
+                  }
+                />
+              </Box>
             </Box>
           </Box>
         </ContentContainer>

--- a/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
+++ b/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
@@ -4,6 +4,8 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
 .c2 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -92,21 +94,14 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
 .c13 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
+  margin-top: 32px;
 }
 
-.c15 {
+.c14 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c16 {
@@ -135,7 +130,9 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c20 {
@@ -154,8 +151,10 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
 .c21 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -189,6 +188,9 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -231,6 +233,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -239,16 +242,18 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   height: 80px;
 }
 
-.c28 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
   width: 100%;
 }
 
-.c32 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   margin-top: 8px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -260,12 +265,14 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: center;
 }
 
-.c37 {
+.c39 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
   margin-left: 4px;
   margin-right: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -283,7 +290,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c39 {
+.c41 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -303,7 +310,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   font-size: 1.5rem;
 }
 
-.c44 {
+.c46 {
   cursor: pointer;
   border: 1px solid core.lightgray;
   background-color: transparent;
@@ -321,11 +328,11 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-width: 1px;
 }
 
-.c44:hover {
+.c46:hover {
   opacity: 0.8;
 }
 
-.c46 {
+.c48 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -341,7 +348,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-width: 1px;
 }
 
-.c46:hover {
+.c48:hover {
   opacity: 0.8;
 }
 
@@ -350,7 +357,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   height: 24;
 }
 
-.c38 {
+.c40 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -358,7 +365,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c40 {
+.c42 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -367,7 +374,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c42 {
+.c44 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -396,22 +403,22 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c33 {
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-right: 4px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
 .c35 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
-  margin: 0;
+  margin-right: 4px;
+  margin-top: 16px;
+}
+
+.c37 {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  display: inline-block;
+  margin-top: 8px;
   margin-bottom: 0;
 }
 
@@ -461,7 +468,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   background: #bacbf7;
 }
 
-.c29 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -486,21 +493,20 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-color: #999999;
 }
 
-.c29:hover {
+.c31:hover {
   background: transparent;
   cursor: initial;
 }
 
-.c29:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
@@ -509,6 +515,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -533,18 +540,22 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   background: #d1ddfa;
 }
 
-.c30 {
+.c29 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: transparent;
+  background-color: #d1ddfa;
   color: #5E26FF;
-  height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  height: 100%;
   min-width: 64px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -579,6 +590,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -602,7 +614,78 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c43 {
+.c28 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c28:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c28:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c28::-webkit-outer-spin-button,
+.c28::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c32 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  background-color: #d1ddfa;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+  background-color: transparent;
+}
+
+.c45 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -675,7 +758,8 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border: 1px solid;
   border-radius: 4px;
   border-color: silver;
-  padding: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -689,7 +773,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c31 {
+.c33 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -723,33 +807,38 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-self: flex-end;
 }
 
-.c31:hover {
+.c33:hover {
   opacity: 0.8;
 }
 
-.c31:hover {
+.c33:hover {
   cursor: pointer;
-}
-
-.c34 {
-  font-size: 0.75rem;
+  opacity: 1;
 }
 
 .c36 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  line-height: 2;
+  font-size: 0.75rem;
 }
 
-.c41 {
+.c38 {
+  -webkit-transition: 0.24s ease-in-out;
+  transition: 0.24s ease-in-out;
+  border-bottom: 2px solid #5E26FF00;
+}
+
+.c38:hover {
+  border-bottom: 2px solid #5E26FF;
+}
+
+.c43 {
   word-wrap: break-word;
 }
 
-.c45 {
+.c47 {
   border-radius: 0px;
 }
 
-.c47 {
+.c49 {
   border-radius: 0px;
 }
 
@@ -864,143 +953,9 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
       >
         <div
           class="c15"
-          display="flex"
         >
           <div
-            class="c16"
-            display="flex"
-          >
-            <h4
-              class="c17"
-              color="core.nearblack"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              Recipient
-            </h4>
-          </div>
-          <div
-            class="c18"
-            display="flex"
-            width="100%"
-          >
-            <input
-              class="c19"
-              display="inline-block"
-              height="7"
-              placeholder="t1..."
-              value=""
-              width="100%"
-            />
-            
-          </div>
-        </div>
-      </div>
-      
-      <div
-        class="c20"
-        display="flex"
-        label="Amount"
-        name="amount"
-      >
-        <div
-          class="c21"
-          color="input.border"
-          display="flex"
-          width="100%"
-        >
-          <h4
-            class="c17"
-            color="core.nearblack"
-            font-family="RT-Alias-Grotesk"
-            font-size="2"
-            font-weight="400"
-          >
-            Amount
-          </h4>
-        </div>
-        <div
-          class="c22"
-          display="inline-block"
-          width="100%"
-        >
-          <div
-            class="c23"
-            display="flex"
-            height="80px"
-            width="100%"
-          >
-            <div
-              class="c24"
-              display="flex"
-              font-family="sansSerif"
-              font-size="5"
-              size="6"
-            >
-              =
-            </div>
-            <input
-              class="c25"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              label="Amount"
-              name="amount"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value=""
-              width="100%"
-            />
-            <div
-              class="c26"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              FIL
-            </div>
-          </div>
-          <div
-            class="c27"
-            display="flex"
-            height="80px"
-          >
-            <input
-              class="c25"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              min="0"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value=""
-              width="100%"
-            />
-            <div
-              class="c26"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              USD
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c28"
-        width="100%"
-      >
-        <div
-          class="c14"
-        >
-          <div
-            class="c15"
+            class="c3"
             display="flex"
           >
             <div
@@ -1014,37 +969,173 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
                 font-size="2"
                 font-weight="400"
               >
-                Transaction Fee
+                Recipient
               </h4>
             </div>
             <div
               class="c18"
               display="flex"
-              width="100%"
             >
               <input
-                class="c29"
-                disabled=""
+                class="c19"
                 display="inline-block"
                 height="7"
-                value="< 0.1"
+                placeholder="t1..."
+                value=""
+                width="100%"
+              />
+              
+            </div>
+          </div>
+        </div>
+        
+        <div
+          class="c20"
+          display="flex"
+          label="Amount"
+          name="amount"
+        >
+          <div
+            class="c21"
+            color="input.border"
+            display="flex"
+            width="100%"
+          >
+            <h4
+              class="c17"
+              color="core.nearblack"
+              font-family="RT-Alias-Grotesk"
+              font-size="2"
+              font-weight="400"
+            >
+              Amount
+            </h4>
+          </div>
+          <div
+            class="c22"
+            display="inline-block"
+            width="100%"
+          >
+            <div
+              class="c23"
+              display="flex"
+              height="80px"
+              width="100%"
+            >
+              <div
+                class="c24"
+                display="flex"
+                font-family="sansSerif"
+                font-size="5"
+                size="6"
+              >
+                =
+              </div>
+              <input
+                class="c25"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                label="Amount"
+                name="amount"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value=""
                 width="100%"
               />
               <div
-                class="c30"
+                class="c26"
                 color="core.primary"
                 display="flex"
                 font-size="3"
-                height="7"
+                height="100%"
               >
                 FIL
+              </div>
+            </div>
+            <div
+              class="c27"
+              display="flex"
+              height="80px"
+            >
+              <input
+                class="c28"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                min="0"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value=""
+                width="100%"
+              />
+              <div
+                class="c29"
+                color="core.primary"
+                display="flex"
+                font-size="3"
+                height="100%"
+              >
+                USD
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c30"
+          width="100%"
+        >
+          <div
+            class="c15"
+          >
+            <div
+              class="c3"
+              display="flex"
+            >
+              <div
+                class="c16"
+                display="flex"
+              >
+                <h4
+                  class="c17"
+                  color="core.nearblack"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="2"
+                  font-weight="400"
+                >
+                  Transaction Fee
+                </h4>
+              </div>
+              <div
+                class="c18"
+                display="flex"
+              >
+                <input
+                  class="c31"
+                  disabled=""
+                  display="inline-block"
+                  height="7"
+                  value="< 0.1"
+                  width="100%"
+                />
+                <div
+                  class="c32"
+                  color="core.primary"
+                  display="flex"
+                  font-size="3"
+                  height="7"
+                >
+                  FIL
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
       <button
-        class="c31"
+        class="c33"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -1052,11 +1143,11 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
         type="button"
       >
         <div
-          class="c32"
+          class="c34"
           display="flex"
         >
           <p
-            class="c33 c34"
+            class="c35 c36"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -1064,7 +1155,8 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
             ▼
           </p>
           <p
-            class="c35 c36"
+            class="c37 c38"
+            display="inline-block"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -1074,11 +1166,11 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
         </div>
       </button>
       <div
-        class="c37"
+        class="c39"
         display="flex"
       >
         <h2
-          class="c38"
+          class="c40"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
@@ -1086,11 +1178,11 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
           Total
         </h2>
         <div
-          class="c39"
+          class="c41"
           display="flex"
         >
           <h2
-            class="c40 c41"
+            class="c42 c43"
             color="core.primary"
             font-family="RT-Alias-Grotesk"
             font-size="5"
@@ -1101,7 +1193,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
             FIL
           </h2>
           <h2
-            class="c42"
+            class="c44"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="4"
@@ -1115,17 +1207,17 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="c43"
+      class="c45"
     >
       <button
-        class="c44 c45 Sendjs___StyledButton-sc-1crplc1-6 c45"
+        class="c46 c47 Sendjs___StyledButton-sc-1crplc1-6 c47"
         font-size="3"
         type="button"
       >
         Back
       </button>
       <button
-        class="c46 c47 Sendjs___StyledButton2-sc-1crplc1-7 c47"
+        class="c48 c49 Sendjs___StyledButton2-sc-1crplc1-7 c49"
         font-size="3"
         type="submit"
       >
@@ -1140,6 +1232,8 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
 .c2 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1228,21 +1322,14 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
 .c13 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
+  margin-top: 32px;
 }
 
-.c15 {
+.c14 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c16 {
@@ -1271,7 +1358,9 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c21 {
@@ -1290,8 +1379,10 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
 .c22 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1325,6 +1416,9 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1367,6 +1461,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1375,16 +1470,18 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   height: 80px;
 }
 
-.c29 {
+.c31 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
   width: 100%;
 }
 
-.c33 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   margin-top: 8px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1396,12 +1493,14 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: center;
 }
 
-.c38 {
+.c40 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
   margin-left: 4px;
   margin-right: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1419,7 +1518,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c40 {
+.c42 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -1439,7 +1538,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   font-size: 1.5rem;
 }
 
-.c45 {
+.c47 {
   cursor: pointer;
   border: 1px solid core.lightgray;
   background-color: transparent;
@@ -1457,11 +1556,11 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-width: 1px;
 }
 
-.c45:hover {
+.c47:hover {
   opacity: 0.8;
 }
 
-.c47 {
+.c49 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -1477,7 +1576,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-width: 1px;
 }
 
-.c47:hover {
+.c49:hover {
   opacity: 0.8;
 }
 
@@ -1486,7 +1585,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   height: 24;
 }
 
-.c39 {
+.c41 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -1494,7 +1593,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c41 {
+.c43 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -1503,7 +1602,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c43 {
+.c45 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -1532,22 +1631,22 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c34 {
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-right: 4px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
 .c36 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
-  margin: 0;
+  margin-right: 4px;
+  margin-top: 16px;
+}
+
+.c38 {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  display: inline-block;
+  margin-top: 8px;
   margin-bottom: 0;
 }
 
@@ -1572,7 +1671,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c30 {
+.c32 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1597,12 +1696,12 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c32:hover {
   background: transparent;
   cursor: initial;
 }
 
-.c30:focus {
+.c32:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
@@ -1645,25 +1744,27 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   background: #FC6D6F;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
-.c31 {
+.c27 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: transparent;
+  background-color: #85e0cb;
   color: #5E26FF;
-  height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  height: 100%;
   min-width: 64px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1679,11 +1780,13 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   background: #d1ddfa;
 }
 
-.c27 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #85e0cb;
@@ -1727,6 +1830,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #85e0cb;
@@ -1750,7 +1854,78 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c44 {
+.c29 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #85e0cb;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #85e0cb;
+  -moz-appearance: textfield;
+}
+
+.c29:hover {
+  background: #85e0cb;
+  cursor: text;
+}
+
+.c29:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #85e0cb;
+}
+
+.c29::-webkit-outer-spin-button,
+.c29::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c33 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  background-color: #d1ddfa;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+  background-color: transparent;
+}
+
+.c46 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -1823,7 +1998,8 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border: 1px solid;
   border-radius: 4px;
   border-color: silver;
-  padding: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1837,7 +2013,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c32 {
+.c34 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -1871,33 +2047,38 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-self: flex-end;
 }
 
-.c32:hover {
+.c34:hover {
   opacity: 0.8;
 }
 
-.c32:hover {
+.c34:hover {
   cursor: pointer;
-}
-
-.c35 {
-  font-size: 0.75rem;
+  opacity: 1;
 }
 
 .c37 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  line-height: 2;
+  font-size: 0.75rem;
 }
 
-.c42 {
+.c39 {
+  -webkit-transition: 0.24s ease-in-out;
+  transition: 0.24s ease-in-out;
+  border-bottom: 2px solid #5E26FF00;
+}
+
+.c39:hover {
+  border-bottom: 2px solid #5E26FF;
+}
+
+.c44 {
   word-wrap: break-word;
 }
 
-.c46 {
+.c48 {
   border-radius: 0px;
 }
 
-.c48 {
+.c50 {
   border-radius: 0px;
 }
 
@@ -2012,151 +2193,9 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
       >
         <div
           class="c15"
-          display="flex"
         >
           <div
-            class="c16"
-            display="flex"
-          >
-            <h4
-              class="c17"
-              color="core.nearblack"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              Recipient
-            </h4>
-          </div>
-          <div
-            class="c18"
-            display="flex"
-            width="100%"
-          >
-            <input
-              class="c19"
-              display="inline-block"
-              height="7"
-              placeholder="t1..."
-              value="t1z225tguggx4onbauimqvxz"
-              width="100%"
-            />
-            
-          </div>
-        </div>
-      </div>
-      <h4
-        class="c20"
-        color="status.fail.background"
-        font-family="RT-Alias-Grotesk"
-        font-size="2"
-        font-weight="400"
-      >
-        Invalid address.
-      </h4>
-      <div
-        class="c21"
-        display="flex"
-        label="Amount"
-        name="amount"
-      >
-        <div
-          class="c22"
-          color="input.border"
-          display="flex"
-          width="100%"
-        >
-          <h4
-            class="c17"
-            color="core.nearblack"
-            font-family="RT-Alias-Grotesk"
-            font-size="2"
-            font-weight="400"
-          >
-            Amount
-          </h4>
-        </div>
-        <div
-          class="c23"
-          display="inline-block"
-          width="100%"
-        >
-          <div
-            class="c24"
-            display="flex"
-            height="80px"
-            width="100%"
-          >
-            <div
-              class="c25"
-              display="flex"
-              font-family="sansSerif"
-              font-size="5"
-              size="6"
-            >
-              =
-            </div>
-            <input
-              class="c26"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              label="Amount"
-              name="amount"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value="0.01"
-              width="100%"
-            />
-            <div
-              class="c27"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              FIL
-            </div>
-          </div>
-          <div
-            class="c28"
-            display="flex"
-            height="80px"
-          >
-            <input
-              class="c26"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              min="0"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value="0.05"
-              width="100%"
-            />
-            <div
-              class="c27"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              USD
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c29"
-        width="100%"
-      >
-        <div
-          class="c14"
-        >
-          <div
-            class="c15"
+            class="c3"
             display="flex"
           >
             <div
@@ -2170,37 +2209,181 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
                 font-size="2"
                 font-weight="400"
               >
-                Transaction Fee
+                Recipient
               </h4>
             </div>
             <div
               class="c18"
               display="flex"
-              width="100%"
             >
               <input
-                class="c30"
-                disabled=""
+                class="c19"
                 display="inline-block"
                 height="7"
-                value="< 0.1"
+                placeholder="t1..."
+                value="t1z225tguggx4onbauimqvxz"
+                width="100%"
+              />
+              
+            </div>
+          </div>
+        </div>
+        <h4
+          class="c20"
+          color="status.fail.background"
+          font-family="RT-Alias-Grotesk"
+          font-size="2"
+          font-weight="400"
+        >
+          Invalid address.
+        </h4>
+        <div
+          class="c21"
+          display="flex"
+          label="Amount"
+          name="amount"
+        >
+          <div
+            class="c22"
+            color="input.border"
+            display="flex"
+            width="100%"
+          >
+            <h4
+              class="c17"
+              color="core.nearblack"
+              font-family="RT-Alias-Grotesk"
+              font-size="2"
+              font-weight="400"
+            >
+              Amount
+            </h4>
+          </div>
+          <div
+            class="c23"
+            display="inline-block"
+            width="100%"
+          >
+            <div
+              class="c24"
+              display="flex"
+              height="80px"
+              width="100%"
+            >
+              <div
+                class="c25"
+                display="flex"
+                font-family="sansSerif"
+                font-size="5"
+                size="6"
+              >
+                =
+              </div>
+              <input
+                class="c26"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                label="Amount"
+                name="amount"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value="0.01"
                 width="100%"
               />
               <div
-                class="c31"
+                class="c27"
                 color="core.primary"
                 display="flex"
                 font-size="3"
-                height="7"
+                height="100%"
               >
                 FIL
+              </div>
+            </div>
+            <div
+              class="c28"
+              display="flex"
+              height="80px"
+            >
+              <input
+                class="c29"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                min="0"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value="0.05"
+                width="100%"
+              />
+              <div
+                class="c30"
+                color="core.primary"
+                display="flex"
+                font-size="3"
+                height="100%"
+              >
+                USD
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c31"
+          width="100%"
+        >
+          <div
+            class="c15"
+          >
+            <div
+              class="c3"
+              display="flex"
+            >
+              <div
+                class="c16"
+                display="flex"
+              >
+                <h4
+                  class="c17"
+                  color="core.nearblack"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="2"
+                  font-weight="400"
+                >
+                  Transaction Fee
+                </h4>
+              </div>
+              <div
+                class="c18"
+                display="flex"
+              >
+                <input
+                  class="c32"
+                  disabled=""
+                  display="inline-block"
+                  height="7"
+                  value="< 0.1"
+                  width="100%"
+                />
+                <div
+                  class="c33"
+                  color="core.primary"
+                  display="flex"
+                  font-size="3"
+                  height="7"
+                >
+                  FIL
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
       <button
-        class="c32"
+        class="c34"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -2208,11 +2391,11 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
         type="button"
       >
         <div
-          class="c33"
+          class="c35"
           display="flex"
         >
           <p
-            class="c34 c35"
+            class="c36 c37"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -2220,7 +2403,8 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
             ▼
           </p>
           <p
-            class="c36 c37"
+            class="c38 c39"
+            display="inline-block"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -2230,11 +2414,11 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
         </div>
       </button>
       <div
-        class="c38"
+        class="c40"
         display="flex"
       >
         <h2
-          class="c39"
+          class="c41"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
@@ -2242,11 +2426,11 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
           Total
         </h2>
         <div
-          class="c40"
+          class="c42"
           display="flex"
         >
           <h2
-            class="c41 c42"
+            class="c43 c44"
             color="core.primary"
             font-family="RT-Alias-Grotesk"
             font-size="5"
@@ -2257,7 +2441,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
             FIL
           </h2>
           <h2
-            class="c43"
+            class="c45"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="4"
@@ -2271,17 +2455,17 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
       </div>
     </div>
     <div
-      class="c44"
+      class="c46"
     >
       <button
-        class="c45 c46 Sendjs___StyledButton-sc-1crplc1-6 c46"
+        class="c47 c48 Sendjs___StyledButton-sc-1crplc1-6 c48"
         font-size="3"
         type="button"
       >
         Back
       </button>
       <button
-        class="c47 c48 Sendjs___StyledButton2-sc-1crplc1-7 c48"
+        class="c49 c50 Sendjs___StyledButton2-sc-1crplc1-7 c50"
         font-size="3"
         type="submit"
       >
@@ -2296,6 +2480,8 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
 .c2 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2384,21 +2570,14 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
 .c13 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
+  margin-top: 32px;
 }
 
-.c15 {
+.c14 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c16 {
@@ -2427,7 +2606,9 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c21 {
@@ -2446,8 +2627,10 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
 .c22 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2481,6 +2664,9 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2523,6 +2709,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2531,16 +2718,18 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   height: 80px;
 }
 
-.c29 {
+.c31 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
   width: 100%;
 }
 
-.c33 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   margin-top: 8px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2552,12 +2741,14 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c38 {
+.c40 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
   margin-left: 4px;
   margin-right: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2575,7 +2766,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c40 {
+.c42 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -2595,7 +2786,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   font-size: 1.5rem;
 }
 
-.c45 {
+.c47 {
   cursor: pointer;
   border: 1px solid core.lightgray;
   background-color: transparent;
@@ -2613,11 +2804,11 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-width: 1px;
 }
 
-.c45:hover {
+.c47:hover {
   opacity: 0.8;
 }
 
-.c47 {
+.c49 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -2633,7 +2824,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-width: 1px;
 }
 
-.c47:hover {
+.c49:hover {
   opacity: 0.8;
 }
 
@@ -2642,7 +2833,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   height: 24;
 }
 
-.c39 {
+.c41 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -2650,7 +2841,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c41 {
+.c43 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -2659,7 +2850,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c43 {
+.c45 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -2688,22 +2879,22 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c34 {
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-right: 4px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
 .c36 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
-  margin: 0;
+  margin-right: 4px;
+  margin-top: 16px;
+}
+
+.c38 {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  display: inline-block;
+  margin-top: 8px;
   margin-bottom: 0;
 }
 
@@ -2728,7 +2919,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c30 {
+.c32 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -2753,12 +2944,12 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c32:hover {
   background: transparent;
   cursor: initial;
 }
 
-.c30:focus {
+.c32:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
@@ -2801,25 +2992,27 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   background: #FC6D6F;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
-.c31 {
+.c27 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: transparent;
+  background-color: #85e0cb;
   color: #5E26FF;
-  height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  height: 100%;
   min-width: 64px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2835,11 +3028,13 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   background: #d1ddfa;
 }
 
-.c27 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #85e0cb;
@@ -2883,6 +3078,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #85e0cb;
@@ -2906,7 +3102,78 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c44 {
+.c29 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #85e0cb;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #85e0cb;
+  -moz-appearance: textfield;
+}
+
+.c29:hover {
+  background: #85e0cb;
+  cursor: text;
+}
+
+.c29:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #85e0cb;
+}
+
+.c29::-webkit-outer-spin-button,
+.c29::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c33 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  background-color: #d1ddfa;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+  background-color: transparent;
+}
+
+.c46 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -2979,7 +3246,8 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border: 1px solid;
   border-radius: 4px;
   border-color: silver;
-  padding: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2993,7 +3261,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c32 {
+.c34 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -3027,33 +3295,38 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-self: flex-end;
 }
 
-.c32:hover {
+.c34:hover {
   opacity: 0.8;
 }
 
-.c32:hover {
+.c34:hover {
   cursor: pointer;
-}
-
-.c35 {
-  font-size: 0.75rem;
+  opacity: 1;
 }
 
 .c37 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  line-height: 2;
+  font-size: 0.75rem;
 }
 
-.c42 {
+.c39 {
+  -webkit-transition: 0.24s ease-in-out;
+  transition: 0.24s ease-in-out;
+  border-bottom: 2px solid #5E26FF00;
+}
+
+.c39:hover {
+  border-bottom: 2px solid #5E26FF;
+}
+
+.c44 {
   word-wrap: break-word;
 }
 
-.c46 {
+.c48 {
   border-radius: 0px;
 }
 
-.c48 {
+.c50 {
   border-radius: 0px;
 }
 
@@ -3168,151 +3441,9 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
       >
         <div
           class="c15"
-          display="flex"
         >
           <div
-            class="c16"
-            display="flex"
-          >
-            <h4
-              class="c17"
-              color="core.nearblack"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              Recipient
-            </h4>
-          </div>
-          <div
-            class="c18"
-            display="flex"
-            width="100%"
-          >
-            <input
-              class="c19"
-              display="inline-block"
-              height="7"
-              placeholder="t1..."
-              value=""
-              width="100%"
-            />
-            
-          </div>
-        </div>
-      </div>
-      <h4
-        class="c20"
-        color="status.fail.background"
-        font-family="RT-Alias-Grotesk"
-        font-size="2"
-        font-weight="400"
-      >
-        Invalid address.
-      </h4>
-      <div
-        class="c21"
-        display="flex"
-        label="Amount"
-        name="amount"
-      >
-        <div
-          class="c22"
-          color="input.border"
-          display="flex"
-          width="100%"
-        >
-          <h4
-            class="c17"
-            color="core.nearblack"
-            font-family="RT-Alias-Grotesk"
-            font-size="2"
-            font-weight="400"
-          >
-            Amount
-          </h4>
-        </div>
-        <div
-          class="c23"
-          display="inline-block"
-          width="100%"
-        >
-          <div
-            class="c24"
-            display="flex"
-            height="80px"
-            width="100%"
-          >
-            <div
-              class="c25"
-              display="flex"
-              font-family="sansSerif"
-              font-size="5"
-              size="6"
-            >
-              =
-            </div>
-            <input
-              class="c26"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              label="Amount"
-              name="amount"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value="0.01"
-              width="100%"
-            />
-            <div
-              class="c27"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              FIL
-            </div>
-          </div>
-          <div
-            class="c28"
-            display="flex"
-            height="80px"
-          >
-            <input
-              class="c26"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              min="0"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value="0.05"
-              width="100%"
-            />
-            <div
-              class="c27"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              USD
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c29"
-        width="100%"
-      >
-        <div
-          class="c14"
-        >
-          <div
-            class="c15"
+            class="c3"
             display="flex"
           >
             <div
@@ -3326,37 +3457,181 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
                 font-size="2"
                 font-weight="400"
               >
-                Transaction Fee
+                Recipient
               </h4>
             </div>
             <div
               class="c18"
               display="flex"
-              width="100%"
             >
               <input
-                class="c30"
-                disabled=""
+                class="c19"
                 display="inline-block"
                 height="7"
-                value="< 0.1"
+                placeholder="t1..."
+                value=""
+                width="100%"
+              />
+              
+            </div>
+          </div>
+        </div>
+        <h4
+          class="c20"
+          color="status.fail.background"
+          font-family="RT-Alias-Grotesk"
+          font-size="2"
+          font-weight="400"
+        >
+          Invalid address.
+        </h4>
+        <div
+          class="c21"
+          display="flex"
+          label="Amount"
+          name="amount"
+        >
+          <div
+            class="c22"
+            color="input.border"
+            display="flex"
+            width="100%"
+          >
+            <h4
+              class="c17"
+              color="core.nearblack"
+              font-family="RT-Alias-Grotesk"
+              font-size="2"
+              font-weight="400"
+            >
+              Amount
+            </h4>
+          </div>
+          <div
+            class="c23"
+            display="inline-block"
+            width="100%"
+          >
+            <div
+              class="c24"
+              display="flex"
+              height="80px"
+              width="100%"
+            >
+              <div
+                class="c25"
+                display="flex"
+                font-family="sansSerif"
+                font-size="5"
+                size="6"
+              >
+                =
+              </div>
+              <input
+                class="c26"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                label="Amount"
+                name="amount"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value="0.01"
                 width="100%"
               />
               <div
-                class="c31"
+                class="c27"
                 color="core.primary"
                 display="flex"
                 font-size="3"
-                height="7"
+                height="100%"
               >
                 FIL
+              </div>
+            </div>
+            <div
+              class="c28"
+              display="flex"
+              height="80px"
+            >
+              <input
+                class="c29"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                min="0"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value="0.05"
+                width="100%"
+              />
+              <div
+                class="c30"
+                color="core.primary"
+                display="flex"
+                font-size="3"
+                height="100%"
+              >
+                USD
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c31"
+          width="100%"
+        >
+          <div
+            class="c15"
+          >
+            <div
+              class="c3"
+              display="flex"
+            >
+              <div
+                class="c16"
+                display="flex"
+              >
+                <h4
+                  class="c17"
+                  color="core.nearblack"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="2"
+                  font-weight="400"
+                >
+                  Transaction Fee
+                </h4>
+              </div>
+              <div
+                class="c18"
+                display="flex"
+              >
+                <input
+                  class="c32"
+                  disabled=""
+                  display="inline-block"
+                  height="7"
+                  value="< 0.1"
+                  width="100%"
+                />
+                <div
+                  class="c33"
+                  color="core.primary"
+                  display="flex"
+                  font-size="3"
+                  height="7"
+                >
+                  FIL
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
       <button
-        class="c32"
+        class="c34"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -3364,11 +3639,11 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
         type="button"
       >
         <div
-          class="c33"
+          class="c35"
           display="flex"
         >
           <p
-            class="c34 c35"
+            class="c36 c37"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -3376,7 +3651,8 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
             ▼
           </p>
           <p
-            class="c36 c37"
+            class="c38 c39"
+            display="inline-block"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -3386,11 +3662,11 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
         </div>
       </button>
       <div
-        class="c38"
+        class="c40"
         display="flex"
       >
         <h2
-          class="c39"
+          class="c41"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
@@ -3398,11 +3674,11 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
           Total
         </h2>
         <div
-          class="c40"
+          class="c42"
           display="flex"
         >
           <h2
-            class="c41 c42"
+            class="c43 c44"
             color="core.primary"
             font-family="RT-Alias-Grotesk"
             font-size="5"
@@ -3413,7 +3689,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
             FIL
           </h2>
           <h2
-            class="c43"
+            class="c45"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="4"
@@ -3427,17 +3703,17 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
       </div>
     </div>
     <div
-      class="c44"
+      class="c46"
     >
       <button
-        class="c45 c46 Sendjs___StyledButton-sc-1crplc1-6 c46"
+        class="c47 c48 Sendjs___StyledButton-sc-1crplc1-6 c48"
         font-size="3"
         type="button"
       >
         Back
       </button>
       <button
-        class="c47 c48 Sendjs___StyledButton2-sc-1crplc1-7 c48"
+        class="c49 c50 Sendjs___StyledButton2-sc-1crplc1-7 c50"
         font-size="3"
         type="submit"
       >
@@ -3452,6 +3728,8 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
 .c2 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3540,21 +3818,14 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
 .c13 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
+  margin-top: 32px;
 }
 
-.c15 {
+.c14 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c16 {
@@ -3583,7 +3854,9 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c20 {
@@ -3602,8 +3875,10 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
 .c21 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3637,6 +3912,9 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3679,6 +3957,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3687,16 +3966,18 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   height: 80px;
 }
 
-.c28 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
   width: 100%;
 }
 
-.c47 {
+.c52 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   margin-top: 8px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3708,12 +3989,14 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   align-items: center;
 }
 
-.c52 {
+.c57 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
   margin-left: 4px;
   margin-right: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3731,7 +4014,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   justify-content: space-between;
 }
 
-.c54 {
+.c59 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -3745,7 +4028,17 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: right;
 }
 
-.c32 {
+.c33 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: silver;
+  margin-top: 8px;
+  padding: 16px;
+}
+
+.c34 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -3762,14 +4055,18 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   align-items: center;
 }
 
-.c35 {
+.c37 {
   min-width: 0;
   box-sizing: border-box;
-  border-color: #999999;
+}
+
+.c38 {
+  min-width: 0;
+  box-sizing: border-box;
   margin-top: 16px;
 }
 
-.c37 {
+.c40 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -3783,7 +4080,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   align-items: center;
 }
 
-.c38 {
+.c41 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 8px;
@@ -3793,10 +4090,12 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: left;
 }
 
-.c40 {
+.c43 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  color: #EFF3FD;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3808,10 +4107,27 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   justify-content: flex-end;
 }
 
-.c43 {
+.c46 {
   min-width: 0;
   box-sizing: border-box;
-  border-color: #999999;
+  border-color: #EFF3FD;
+}
+
+.c48 {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+  border-top: 1px solid;
+  color: #EFF3FD;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
 .c5 {
@@ -3820,7 +4136,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   font-size: 1.5rem;
 }
 
-.c59 {
+.c64 {
   cursor: pointer;
   border: 1px solid core.lightgray;
   background-color: transparent;
@@ -3838,11 +4154,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-width: 1px;
 }
 
-.c59:hover {
+.c64:hover {
   opacity: 0.8;
 }
 
-.c61 {
+.c66 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -3858,7 +4174,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-width: 1px;
 }
 
-.c61:hover {
+.c66:hover {
   opacity: 0.8;
 }
 
@@ -3867,7 +4183,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   height: 24;
 }
 
-.c53 {
+.c58 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -3875,7 +4191,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c55 {
+.c60 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -3884,7 +4200,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c57 {
+.c62 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -3913,22 +4229,23 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin-bottom: 0;
 }
 
-.c48 {
+.c55 {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  display: inline-block;
+  margin-top: 8px;
+  margin-bottom: 0;
+}
+
+.c53 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
   margin-right: 4px;
   margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c50 {
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
   margin-bottom: 0;
 }
 
@@ -3941,7 +4258,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c33 {
+.c35 {
   color: #666666;
   font-size: 1.125rem;
   font-weight: 400;
@@ -3953,7 +4270,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   padding-left: 8px;
 }
 
-.c39 {
+.c42 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1;
@@ -3998,7 +4315,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   background: #bacbf7;
 }
 
-.c29 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -4023,36 +4340,37 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-color: #999999;
 }
 
-.c29:hover {
+.c31:hover {
   background: transparent;
   cursor: initial;
 }
 
-.c29:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
-.c36 {
+.c39 {
   display: inline-block;
   width: 100%;
   margin-top: 8px;
   margin: 0;
+  border-top-left-radius: 4px;
   border-radius: 1px;
 }
 
-.c44 {
+.c47 {
   display: inline-block;
   width: 100%;
   margin: 0;
+  border-bottom-left-radius: 4px;
   border-radius: 1px;
 }
 
@@ -4061,6 +4379,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -4085,13 +4404,45 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   background: #d1ddfa;
 }
 
-.c30 {
+.c29 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: transparent;
+  background-color: #d1ddfa;
   color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c45 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-top-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  background-color: #d1ddfa;
   height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4110,11 +4461,14 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: center;
   position: relative;
   background: #d1ddfa;
+  top: 0px;
+  left: 0px;
 }
 
-.c42 {
+.c50 {
   min-width: 0;
   box-sizing: border-box;
+  border-bottom-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   color: #5E26FF;
@@ -4160,6 +4514,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -4183,7 +4538,50 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c41 {
+.c28 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c28:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c28:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c28::-webkit-outer-spin-button,
+.c28::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c44 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -4204,30 +4602,31 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   display: inline-block;
   height: 64px;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
-.c41:hover {
+.c44:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c41:focus {
+.c44:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c41::-webkit-outer-spin-button,
-.c41::-webkit-inner-spin-button {
+.c44::-webkit-outer-spin-button,
+.c44::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.c45 {
+.c49 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -4247,30 +4646,59 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   display: inline-block;
   height: 64px;
   width: 100%;
+  border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
-.c45:hover {
+.c49:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c45:focus {
+.c49:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c45::-webkit-outer-spin-button,
-.c45::-webkit-inner-spin-button {
+.c49::-webkit-outer-spin-button,
+.c49::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.c58 {
+.c32 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  background-color: #d1ddfa;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+  background-color: transparent;
+}
+
+.c63 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -4302,7 +4730,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   width: 40%;
 }
 
-.c34 {
+.c36 {
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: 0.18s ease-in-out;
@@ -4313,7 +4741,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin-top: 0;
 }
 
-.c34:hover {
+.c36:hover {
   border-bottom: 2px solid #5E26FF;
 }
 
@@ -4353,33 +4781,13 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   min-width: 300px;
 }
 
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-box-flex: 2;
-  -webkit-flex-grow: 2;
-  -ms-flex-positive: 2;
-  flex-grow: 2;
-  max-width: 560px;
-  min-width: 300px;
-  margin-top: 8px;
-}
-
 .c1 {
   background-color: #EFF3FD;
   border: 1px solid;
   border-radius: 4px;
   border-color: silver;
-  padding: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4393,7 +4801,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   justify-content: space-between;
 }
 
-.c46 {
+.c51 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -4427,44 +4835,49 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   align-self: flex-end;
 }
 
-.c46:hover {
+.c51:hover {
   opacity: 0.8;
 }
 
-.c46:hover {
+.c51:hover {
   cursor: pointer;
+  opacity: 1;
 }
 
-.c49 {
+.c54 {
   font-size: 0.75rem;
 }
 
-.c51 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  line-height: 2;
+.c56 {
+  -webkit-transition: 0.24s ease-in-out;
+  transition: 0.24s ease-in-out;
+  border-bottom: 2px solid #5E26FF00;
 }
 
-.c56 {
+.c56:hover {
+  border-bottom: 2px solid #5E26FF;
+}
+
+.c61 {
   word-wrap: break-word;
 }
 
-.c60 {
+.c65 {
   border-radius: 0px;
 }
 
-.c62 {
+.c67 {
   border-radius: 0px;
 }
 
 @media screen and (min-width:40em) {
-  .c38 {
+  .c41 {
     min-width: 160px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c38 {
+  .c41 {
     min-width: 240px;
   }
 }
@@ -4580,143 +4993,9 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
       >
         <div
           class="c15"
-          display="flex"
         >
           <div
-            class="c16"
-            display="flex"
-          >
-            <h4
-              class="c17"
-              color="core.nearblack"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              Recipient
-            </h4>
-          </div>
-          <div
-            class="c18"
-            display="flex"
-            width="100%"
-          >
-            <input
-              class="c19"
-              display="inline-block"
-              height="7"
-              placeholder="t1..."
-              value=""
-              width="100%"
-            />
-            
-          </div>
-        </div>
-      </div>
-      
-      <div
-        class="c20"
-        display="flex"
-        label="Amount"
-        name="amount"
-      >
-        <div
-          class="c21"
-          color="input.border"
-          display="flex"
-          width="100%"
-        >
-          <h4
-            class="c17"
-            color="core.nearblack"
-            font-family="RT-Alias-Grotesk"
-            font-size="2"
-            font-weight="400"
-          >
-            Amount
-          </h4>
-        </div>
-        <div
-          class="c22"
-          display="inline-block"
-          width="100%"
-        >
-          <div
-            class="c23"
-            display="flex"
-            height="80px"
-            width="100%"
-          >
-            <div
-              class="c24"
-              display="flex"
-              font-family="sansSerif"
-              font-size="5"
-              size="6"
-            >
-              =
-            </div>
-            <input
-              class="c25"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              label="Amount"
-              name="amount"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value=""
-              width="100%"
-            />
-            <div
-              class="c26"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              FIL
-            </div>
-          </div>
-          <div
-            class="c27"
-            display="flex"
-            height="80px"
-          >
-            <input
-              class="c25"
-              display="inline-block"
-              font-size="5"
-              height="100%"
-              min="0"
-              placeholder="0"
-              step="0.000000000000000001"
-              type="number"
-              value=""
-              width="100%"
-            />
-            <div
-              class="c26"
-              color="core.primary"
-              display="flex"
-              font-size="3"
-              height="100%"
-            >
-              USD
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c28"
-        width="100%"
-      >
-        <div
-          class="c14"
-        >
-          <div
-            class="c15"
+            class="c3"
             display="flex"
           >
             <div
@@ -4730,44 +5009,180 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
                 font-size="2"
                 font-weight="400"
               >
-                Transaction Fee
+                Recipient
               </h4>
             </div>
             <div
               class="c18"
               display="flex"
-              width="100%"
             >
               <input
-                class="c29"
-                disabled=""
+                class="c19"
                 display="inline-block"
                 height="7"
-                value="122"
+                placeholder="t1..."
+                value=""
+                width="100%"
+              />
+              
+            </div>
+          </div>
+        </div>
+        
+        <div
+          class="c20"
+          display="flex"
+          label="Amount"
+          name="amount"
+        >
+          <div
+            class="c21"
+            color="input.border"
+            display="flex"
+            width="100%"
+          >
+            <h4
+              class="c17"
+              color="core.nearblack"
+              font-family="RT-Alias-Grotesk"
+              font-size="2"
+              font-weight="400"
+            >
+              Amount
+            </h4>
+          </div>
+          <div
+            class="c22"
+            display="inline-block"
+            width="100%"
+          >
+            <div
+              class="c23"
+              display="flex"
+              height="80px"
+              width="100%"
+            >
+              <div
+                class="c24"
+                display="flex"
+                font-family="sansSerif"
+                font-size="5"
+                size="6"
+              >
+                =
+              </div>
+              <input
+                class="c25"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                label="Amount"
+                name="amount"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value=""
                 width="100%"
               />
               <div
-                class="c30"
+                class="c26"
                 color="core.primary"
                 display="flex"
                 font-size="3"
-                height="7"
+                height="100%"
               >
-                AttoFil
+                FIL
+              </div>
+            </div>
+            <div
+              class="c27"
+              display="flex"
+              height="80px"
+            >
+              <input
+                class="c28"
+                display="inline-block"
+                font-size="5"
+                height="100%"
+                min="0"
+                placeholder="0"
+                step="0.000000000000000001"
+                type="number"
+                value=""
+                width="100%"
+              />
+              <div
+                class="c29"
+                color="core.primary"
+                display="flex"
+                font-size="3"
+                height="100%"
+              >
+                USD
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c30"
+          width="100%"
+        >
+          <div
+            class="c15"
+          >
+            <div
+              class="c3"
+              display="flex"
+            >
+              <div
+                class="c16"
+                display="flex"
+              >
+                <h4
+                  class="c17"
+                  color="core.nearblack"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="2"
+                  font-weight="400"
+                >
+                  Transaction Fee
+                </h4>
+              </div>
+              <div
+                class="c18"
+                display="flex"
+              >
+                <input
+                  class="c31"
+                  disabled=""
+                  display="inline-block"
+                  height="7"
+                  value="122"
+                  width="100%"
+                />
+                <div
+                  class="c32"
+                  color="core.primary"
+                  display="flex"
+                  font-size="3"
+                  height="7"
+                >
+                  AttoFil
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        class="c31"
+        class="c33"
       >
         <div
-          class="c32"
+          class="c34"
           display="flex"
         >
           <h4
-            class="c33"
+            class="c35"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="2"
@@ -4776,7 +5191,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
             Transfers complete faster with a higher gas price.
           </h4>
           <a
-            class="c34"
+            class="c36"
             color="core.primary"
             font-size="3"
             href="https://kb.myetherwallet.com/en/transactions/what-is-gas/"
@@ -4787,93 +5202,48 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
           </a>
         </div>
         <div
-          class="c35"
+          class="c37"
         >
           <div
-            class="c36"
+            class="c38"
           >
             <div
-              class="c37"
-              display="flex"
+              class="c39"
             >
-              <div
-                class="c38"
-                display="inline-block"
-              >
-                <h4
-                  class="c39"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Gas Price
-                </h4>
-              </div>
               <div
                 class="c40"
                 display="flex"
-                width="100%"
               >
-                <input
+                <div
                   class="c41"
-                  display="inline-block"
-                  font-size="2"
-                  height="7"
-                  type="number"
-                  value="1"
-                  width="100%"
-                />
-                <div
-                  class="c42"
-                  color="core.primary"
-                  display="flex"
-                  font-size="3"
-                  height="64px"
-                >
-                  AttoFil
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c43"
-          >
-            <div
-              class="c44"
-            >
-              <div
-                class="c37"
-                display="flex"
-              >
-                <div
-                  class="c38"
                   display="inline-block"
                 >
                   <h4
-                    class="c39"
+                    class="c42"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    Gas Limit
+                    Gas Price
                   </h4>
                 </div>
                 <div
-                  class="c40"
+                  class="c43"
+                  color="background.screen"
                   display="flex"
                   width="100%"
                 >
                   <input
-                    class="c45"
+                    class="c44"
                     display="inline-block"
                     font-size="2"
                     height="7"
                     type="number"
-                    value="2000"
+                    value="1"
                     width="100%"
                   />
                   <div
-                    class="c42"
+                    class="c45"
                     color="core.primary"
                     display="flex"
                     font-size="3"
@@ -4884,11 +5254,62 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="c46"
+            >
+              <div
+                class="c47"
+              >
+                <div
+                  class="c40"
+                  display="flex"
+                >
+                  <div
+                    class="c41"
+                    display="inline-block"
+                  >
+                    <h4
+                      class="c42"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Gas Limit
+                    </h4>
+                  </div>
+                  <div
+                    class="c48"
+                    color="background.screen"
+                    display="flex"
+                    width="100%"
+                  >
+                    <input
+                      class="c49"
+                      display="inline-block"
+                      font-size="2"
+                      height="7"
+                      type="number"
+                      value="2000"
+                      width="100%"
+                    />
+                    <div
+                      class="c50"
+                      color="core.primary"
+                      display="flex"
+                      font-size="3"
+                      height="64px"
+                    >
+                      AttoFil
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
       <button
-        class="c46"
+        class="c51"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -4896,11 +5317,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
         type="button"
       >
         <div
-          class="c47"
+          class="c52"
           display="flex"
         >
           <p
-            class="c48 c49"
+            class="c53 c54"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -4908,7 +5329,8 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
             ▲
           </p>
           <p
-            class="c50 c51"
+            class="c55 c56"
+            display="inline-block"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -4918,11 +5340,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
         </div>
       </button>
       <div
-        class="c52"
+        class="c57"
         display="flex"
       >
         <h2
-          class="c53"
+          class="c58"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
@@ -4930,11 +5352,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
           Total
         </h2>
         <div
-          class="c54"
+          class="c59"
           display="flex"
         >
           <h2
-            class="c55 c56"
+            class="c60 c61"
             color="core.primary"
             font-family="RT-Alias-Grotesk"
             font-size="5"
@@ -4945,7 +5367,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
             FIL
           </h2>
           <h2
-            class="c57"
+            class="c62"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="4"
@@ -4959,17 +5381,17 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
       </div>
     </div>
     <div
-      class="c58"
+      class="c63"
     >
       <button
-        class="c59 c60 Sendjs___StyledButton-sc-1crplc1-6 c60"
+        class="c64 c65 Sendjs___StyledButton-sc-1crplc1-6 c65"
         font-size="3"
         type="button"
       >
         Back
       </button>
       <button
-        class="c61 c62 Sendjs___StyledButton2-sc-1crplc1-7 c62"
+        class="c66 c67 Sendjs___StyledButton2-sc-1crplc1-7 c67"
         font-size="3"
         type="submit"
       >

--- a/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
+++ b/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
@@ -205,7 +205,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -231,10 +231,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -482,7 +479,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background-color: #EFF3FD;
+  background: transparent;
   padding-left: 16px;
   padding-right: 16px;
   display: inline-block;
@@ -518,7 +515,6 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -546,10 +542,8 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -569,6 +563,33 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   text-align: center;
   position: relative;
   background: #d1ddfa;
+}
+
+.c32 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: transparent;
+  color: #5E26FF;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: core.transparent;
 }
 
 .c25 {
@@ -593,7 +614,6 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -636,7 +656,6 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -655,34 +674,6 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
 .c28::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c32 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  background-color: #d1ddfa;
-  height: 64px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #d1ddfa;
-  background-color: transparent;
 }
 
 .c45 {
@@ -1433,7 +1424,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -1459,10 +1450,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1685,7 +1673,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background-color: #EFF3FD;
+  background: transparent;
   padding-left: 16px;
   padding-right: 16px;
   display: inline-block;
@@ -1750,6 +1738,33 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-radius: 1px;
 }
 
+.c33 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: transparent;
+  color: #5E26FF;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: core.transparent;
+}
+
 .c27 {
   min-width: 0;
   box-sizing: border-box;
@@ -1758,7 +1773,6 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1777,7 +1791,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: #85e0cb;
 }
 
 .c30 {
@@ -1786,10 +1800,8 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1808,7 +1820,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: #85e0cb;
 }
 
 .c26 {
@@ -1833,7 +1845,6 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
@@ -1876,7 +1887,6 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
@@ -1895,34 +1905,6 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
 .c29::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c33 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  background-color: #d1ddfa;
-  height: 64px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #d1ddfa;
-  background-color: transparent;
 }
 
 .c46 {
@@ -2681,7 +2663,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -2707,10 +2689,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2933,7 +2912,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background-color: #EFF3FD;
+  background: transparent;
   padding-left: 16px;
   padding-right: 16px;
   display: inline-block;
@@ -2998,6 +2977,33 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-radius: 1px;
 }
 
+.c33 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: transparent;
+  color: #5E26FF;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: core.transparent;
+}
+
 .c27 {
   min-width: 0;
   box-sizing: border-box;
@@ -3006,7 +3012,6 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3025,7 +3030,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: #85e0cb;
 }
 
 .c30 {
@@ -3034,10 +3039,8 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #85e0cb;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3056,7 +3059,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   font-size: 1.25rem;
   text-align: center;
   position: relative;
-  background: #d1ddfa;
+  background: #85e0cb;
 }
 
 .c26 {
@@ -3081,7 +3084,6 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
@@ -3124,7 +3126,6 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #85e0cb;
   -moz-appearance: textfield;
 }
 
@@ -3143,34 +3144,6 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
 .c29::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c33 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  background-color: #d1ddfa;
-  height: 64px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #d1ddfa;
-  background-color: transparent;
 }
 
 .c46 {
@@ -3929,7 +3902,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -3955,10 +3928,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3973,7 +3943,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   width: 100%;
 }
 
-.c52 {
+.c51 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 16px;
@@ -3989,7 +3959,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   align-items: center;
 }
 
-.c57 {
+.c56 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
@@ -4014,7 +3984,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   justify-content: space-between;
 }
 
-.c59 {
+.c58 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -4095,6 +4065,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   box-sizing: border-box;
   position: relative;
   border-bottom: 1px solid;
+  border-top: 1px solid;
   color: #EFF3FD;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4113,30 +4084,13 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-color: #EFF3FD;
 }
 
-.c48 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  border-top: 1px solid;
-  color: #EFF3FD;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
 .c5 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c64 {
+.c63 {
   cursor: pointer;
   border: 1px solid core.lightgray;
   background-color: transparent;
@@ -4154,11 +4108,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-width: 1px;
 }
 
-.c64:hover {
+.c63:hover {
   opacity: 0.8;
 }
 
-.c66 {
+.c65 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -4174,7 +4128,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-width: 1px;
 }
 
-.c66:hover {
+.c65:hover {
   opacity: 0.8;
 }
 
@@ -4183,7 +4137,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   height: 24;
 }
 
-.c58 {
+.c57 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -4191,7 +4145,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c60 {
+.c59 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -4200,7 +4154,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c62 {
+.c61 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -4229,7 +4183,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin-bottom: 0;
 }
 
-.c55 {
+.c54 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -4239,7 +4193,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin-bottom: 0;
 }
 
-.c53 {
+.c52 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -4329,7 +4283,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background-color: #EFF3FD;
+  background: transparent;
   padding-left: 16px;
   padding-right: 16px;
   display: inline-block;
@@ -4362,7 +4316,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   width: 100%;
   margin-top: 8px;
   margin: 0;
-  border-top-left-radius: 4px;
   border-radius: 1px;
 }
 
@@ -4370,7 +4323,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   display: inline-block;
   width: 100%;
   margin: 0;
-  border-bottom-left-radius: 4px;
   border-radius: 1px;
 }
 
@@ -4382,7 +4334,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4410,10 +4361,8 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4435,14 +4384,42 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   background: #d1ddfa;
 }
 
+.c32 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: transparent;
+  color: #5E26FF;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: core.transparent;
+}
+
 .c45 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   color: #5E26FF;
-  background-color: #d1ddfa;
   height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4461,18 +4438,17 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: center;
   position: relative;
   background: #d1ddfa;
-  top: 0px;
-  left: 0px;
 }
 
-.c50 {
+.c49 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
   border-bottom-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   color: #5E26FF;
-  background-color: #d1ddfa;
   height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4491,8 +4467,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: center;
   position: relative;
   background: #d1ddfa;
-  top: 0px;
-  left: 0px;
 }
 
 .c25 {
@@ -4517,7 +4491,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -4560,7 +4533,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -4596,16 +4568,12 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: right;
   cursor: text;
   background: #d1ddfa;
-  font-size: 1.125rem;
-  margin-top: 8px;
-  margin: 0;
   display: inline-block;
   height: 64px;
   width: 100%;
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -4626,7 +4594,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   margin: 0;
 }
 
-.c49 {
+.c48 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -4641,64 +4609,33 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   text-align: right;
   cursor: text;
   background: #d1ddfa;
-  font-size: 1.125rem;
-  margin: 0;
   display: inline-block;
   height: 64px;
   width: 100%;
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
-.c49:hover {
+.c48:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c49:focus {
+.c48:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c49::-webkit-outer-spin-button,
-.c49::-webkit-inner-spin-button {
+.c48::-webkit-outer-spin-button,
+.c48::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.c32 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  background-color: #d1ddfa;
-  height: 64px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #d1ddfa;
-  background-color: transparent;
-}
-
-.c63 {
+.c62 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -4801,7 +4738,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   justify-content: space-between;
 }
 
-.c51 {
+.c50 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -4835,38 +4772,38 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
   align-self: flex-end;
 }
 
-.c51:hover {
+.c50:hover {
   opacity: 0.8;
 }
 
-.c51:hover {
+.c50:hover {
   cursor: pointer;
   opacity: 1;
 }
 
-.c54 {
+.c53 {
   font-size: 0.75rem;
 }
 
-.c56 {
+.c55 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
 }
 
-.c56:hover {
+.c55:hover {
   border-bottom: 2px solid #5E26FF;
 }
 
-.c61 {
+.c60 {
   word-wrap: break-word;
 }
 
-.c65 {
+.c64 {
   border-radius: 0px;
 }
 
-.c67 {
+.c66 {
   border-radius: 0px;
 }
 
@@ -5236,7 +5173,6 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
                   <input
                     class="c44"
                     display="inline-block"
-                    font-size="2"
                     height="7"
                     type="number"
                     value="1"
@@ -5278,22 +5214,21 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
                     </h4>
                   </div>
                   <div
-                    class="c48"
+                    class="c43"
                     color="background.screen"
                     display="flex"
                     width="100%"
                   >
                     <input
-                      class="c49"
+                      class="c48"
                       display="inline-block"
-                      font-size="2"
                       height="7"
                       type="number"
                       value="2000"
                       width="100%"
                     />
                     <div
-                      class="c50"
+                      class="c49"
                       color="core.primary"
                       display="flex"
                       font-size="3"
@@ -5309,7 +5244,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
         </div>
       </div>
       <button
-        class="c51"
+        class="c50"
         color="core.primary"
         display="flex"
         font-size="3"
@@ -5317,11 +5252,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
         type="button"
       >
         <div
-          class="c52"
+          class="c51"
           display="flex"
         >
           <p
-            class="c53 c54"
+            class="c52 c53"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -5329,7 +5264,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
             ▲
           </p>
           <p
-            class="c55 c56"
+            class="c54 c55"
             display="inline-block"
             font-family="RT-Alias-Grotesk"
             font-size="3"
@@ -5340,11 +5275,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
         </div>
       </button>
       <div
-        class="c57"
+        class="c56"
         display="flex"
       >
         <h2
-          class="c58"
+          class="c57"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
@@ -5352,11 +5287,11 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
           Total
         </h2>
         <div
-          class="c59"
+          class="c58"
           display="flex"
         >
           <h2
-            class="c60 c61"
+            class="c59 c60"
             color="core.primary"
             font-family="RT-Alias-Grotesk"
             font-size="5"
@@ -5367,7 +5302,7 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
             FIL
           </h2>
           <h2
-            class="c62"
+            class="c61"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="4"
@@ -5381,17 +5316,17 @@ exports[`Send Flow snapshots it renders the gas customization view 1`] = `
       </div>
     </div>
     <div
-      class="c63"
+      class="c62"
     >
       <button
-        class="c64 c65 Sendjs___StyledButton-sc-1crplc1-6 c65"
+        class="c63 c64 Sendjs___StyledButton-sc-1crplc1-6 c64"
         font-size="3"
         type="button"
       >
         Back
       </button>
       <button
-        class="c66 c67 Sendjs___StyledButton2-sc-1crplc1-7 c67"
+        class="c65 c66 Sendjs___StyledButton2-sc-1crplc1-7 c66"
         font-size="3"
         type="submit"
       >

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -300,7 +300,7 @@ const Send = ({ close }) => {
               />
             </Box>
           </Box>
-          <Box mt={3}>
+          <Box mt={5}>
             <Input.Address
               name='recipient'
               onChange={e => setToAddress(e.target.value)}

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -334,7 +334,6 @@ const Send = ({ close }) => {
                   value={
                     customizingGas ? estimatedGasUsed.toAttoFil() : '< 0.1'
                   }
-                  backgroundColor='background.screen'
                   disabled
                 />
               </Box>
@@ -397,10 +396,10 @@ const Send = ({ close }) => {
                   css={`
                     transition: 0.24s ease-in-out;
                     border-bottom: 2px solid
-                      ${props => props.theme.colors.core.primary}00;
+                      ${({ theme }) => theme.colors.core.primary}00;
                     &:hover {
                       border-bottom: 2px solid
-                        ${props => props.theme.colors.core.primary};
+                        ${({ theme }) => theme.colors.core.primary};
                     }
                   `}
                   mb={0}

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -39,7 +39,7 @@ const SendCardForm = styled.form.attrs(() => ({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-  p: 3,
+  py: 3,
   border: 1,
   borderRadius: 2,
   borderColor: 'silver',
@@ -267,6 +267,7 @@ const Send = ({ close }) => {
             display='flex'
             alignItems='center'
             justifyContent='space-between'
+            px={3}
           >
             <Box display='flex' alignItems='center'>
               <Glyph
@@ -301,38 +302,42 @@ const Send = ({ close }) => {
             </Box>
           </Box>
           <Box mt={5}>
-            <Input.Address
-              name='recipient'
-              onChange={e => setToAddress(e.target.value)}
-              value={toAddress}
-              label='Recipient'
-              placeholder='t1...'
-              error={toAddressError}
-              setError={setToAddressError}
-              disabled={step === 2 && !hasError()}
-              valid={validateAddressString(toAddress)}
-            />
-            <Input.Funds
-              name='amount'
-              label='Amount'
-              amount={value.toAttoFil()}
-              onAmountChange={setValue}
-              balance={wallet.balance}
-              error={valueError}
-              setError={setValueError}
-              gasLimit={gasLimit}
-              disabled={step === 2 && !hasError()}
-              valid={isValidAmount(value, wallet.balance, valueError)}
-            />
-            <Box position='relative' width='100%'>
-              <Input.Text
-                onChange={noop}
-                denom={customizingGas ? 'AttoFil' : 'FIL'}
-                label='Transaction Fee'
-                value={customizingGas ? estimatedGasUsed.toAttoFil() : '< 0.1'}
-                backgroundColor='background.screen'
-                disabled
+            <Box px={3}>
+              <Input.Address
+                name='recipient'
+                onChange={e => setToAddress(e.target.value)}
+                value={toAddress}
+                label='Recipient'
+                placeholder='t1...'
+                error={toAddressError}
+                setError={setToAddressError}
+                disabled={step === 2 && !hasError()}
+                valid={validateAddressString(toAddress)}
               />
+              <Input.Funds
+                name='amount'
+                label='Amount'
+                amount={value.toAttoFil()}
+                onAmountChange={setValue}
+                balance={wallet.balance}
+                error={valueError}
+                setError={setValueError}
+                gasLimit={gasLimit}
+                disabled={step === 2 && !hasError()}
+                valid={isValidAmount(value, wallet.balance, valueError)}
+              />
+              <Box position='relative' width='100%'>
+                <Input.Text
+                  onChange={noop}
+                  denom={customizingGas ? 'AttoFil' : 'FIL'}
+                  label='Transaction Fee'
+                  value={
+                    customizingGas ? estimatedGasUsed.toAttoFil() : '< 0.1'
+                  }
+                  backgroundColor='background.screen'
+                  disabled
+                />
+              </Box>
             </Box>
             <GasCustomization
               show={customizingGas}
@@ -356,6 +361,7 @@ const Send = ({ close }) => {
                 outline: none;
                 &:hover {
                   cursor: pointer;
+                  opacity: 1;
                 }
                 align-self: flex-end;
               `}
@@ -363,7 +369,7 @@ const Send = ({ close }) => {
               alignItems='center'
               flexDirection='row'
             >
-              <Box display='flex' alignItems='center' mt={2}>
+              <Box display='flex' alignItems='center' px={3} mt={2}>
                 {customizingGas ? (
                   <Text
                     css={`
@@ -380,16 +386,22 @@ const Send = ({ close }) => {
                       font-size: 0.75rem;
                     `}
                     mr={1}
-                    my={0}
+                    mt={3}
                   >
                     &#9660;
                   </Text>
                 )}
                 <Text
-                  m={0}
+                  display='inline-block'
+                  my={2}
                   css={`
-                    text-decoration: underline;
-                    line-height: 2;
+                    transition: 0.24s ease-in-out;
+                    border-bottom: 2px solid
+                      ${props => props.theme.colors.core.primary}00;
+                    &:hover {
+                      border-bottom: 2px solid
+                        ${props => props.theme.colors.core.primary};
+                    }
                   `}
                   mb={0}
                 >
@@ -404,6 +416,7 @@ const Send = ({ close }) => {
               justifyContent='space-between'
               mt={5}
               mx={1}
+              px={3}
             >
               <Total fontSize={4} alignSelf='flex-start'>
                 Total

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -5002,6 +5002,8 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
 .c40 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5090,21 +5092,14 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
 .c49 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
+  margin-top: 32px;
 }
 
-.c51 {
+.c50 {
   min-width: 0;
   box-sizing: border-box;
-  padding-left: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c52 {
@@ -5133,7 +5128,9 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c56 {
@@ -5152,8 +5149,10 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
 .c57 {
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 4px;
   padding-left: 8px;
   padding-right: 8px;
+  margin-right: 8px;
   color: #999999;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5187,6 +5186,9 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5229,6 +5231,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   position: relative;
   border-top: 1px solid;
   border-color: #EFF3FD;
+  border-radius: 4px;
   background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5237,16 +5240,18 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   height: 80px;
 }
 
-.c64 {
+.c66 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
   width: 100%;
 }
 
-.c68 {
+.c70 {
   min-width: 0;
   box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
   margin-top: 8px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5258,12 +5263,14 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   align-items: center;
 }
 
-.c73 {
+.c75 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 32px;
   margin-left: 4px;
   margin-right: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5281,7 +5288,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   justify-content: space-between;
 }
 
-.c75 {
+.c77 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -5364,7 +5371,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   opacity: 1;
 }
 
-.c80 {
+.c82 {
   cursor: pointer;
   border: 1px solid core.lightgray;
   background-color: transparent;
@@ -5382,11 +5389,11 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-width: 1px;
 }
 
-.c80:hover {
+.c82:hover {
   opacity: 0.8;
 }
 
-.c82 {
+.c84 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -5402,7 +5409,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-width: 1px;
 }
 
-.c82:hover {
+.c84:hover {
   opacity: 0.8;
 }
 
@@ -5445,7 +5452,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   margin: 0;
 }
 
-.c74 {
+.c76 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -5453,7 +5460,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   margin: 0;
 }
 
-.c76 {
+.c78 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
@@ -5462,7 +5469,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   margin: 0;
 }
 
-.c78 {
+.c80 {
   color: #666666;
   font-size: 1.5rem;
   font-weight: 400;
@@ -5498,22 +5505,22 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   margin-bottom: 0;
 }
 
-.c69 {
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-right: 4px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
 .c71 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
-  margin: 0;
+  margin-right: 4px;
+  margin-top: 16px;
+}
+
+.c73 {
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  display: inline-block;
+  margin-top: 8px;
   margin-bottom: 0;
 }
 
@@ -5664,7 +5671,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   background: #bacbf7;
 }
 
-.c65 {
+.c67 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -5689,21 +5696,20 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-color: #999999;
 }
 
-.c65:hover {
+.c67:hover {
   background: transparent;
   cursor: initial;
 }
 
-.c65:focus {
+.c67:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c50 {
+.c51 {
   display: inline-block;
   width: 100%;
-  margin-top: 16px;
   border-radius: 1px;
 }
 
@@ -5712,6 +5718,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   box-sizing: border-box;
   top: 0px;
   left: 0px;
+  border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
   background-color: #d1ddfa;
@@ -5736,18 +5743,22 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   background: #d1ddfa;
 }
 
-.c66 {
+.c65 {
   min-width: 0;
   box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: transparent;
+  background-color: #d1ddfa;
   color: #5E26FF;
-  height: 64px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  height: 100%;
   min-width: 64px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -5782,6 +5793,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   height: 100%;
   display: inline-block;
   width: 100%;
+  border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
   background: #d1ddfa;
@@ -5805,7 +5817,78 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   margin: 0;
 }
 
-.c79 {
+.c64 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: right;
+  cursor: text;
+  background: #d1ddfa;
+  font-size: 2rem;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  background: #d1ddfa;
+  -moz-appearance: textfield;
+}
+
+.c64:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c64:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c64::-webkit-outer-spin-button,
+.c64::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c68 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  background-color: #d1ddfa;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+  background-color: transparent;
+}
+
+.c81 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -5988,7 +6071,8 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border: 1px solid;
   border-radius: 4px;
   border-color: silver;
-  padding: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6002,7 +6086,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   justify-content: space-between;
 }
 
-.c67 {
+.c69 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -6036,33 +6120,38 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   align-self: flex-end;
 }
 
-.c67:hover {
+.c69:hover {
   opacity: 0.8;
 }
 
-.c67:hover {
+.c69:hover {
   cursor: pointer;
-}
-
-.c70 {
-  font-size: 0.75rem;
+  opacity: 1;
 }
 
 .c72 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  line-height: 2;
+  font-size: 0.75rem;
 }
 
-.c77 {
+.c74 {
+  -webkit-transition: 0.24s ease-in-out;
+  transition: 0.24s ease-in-out;
+  border-bottom: 2px solid #5E26FF00;
+}
+
+.c74:hover {
+  border-bottom: 2px solid #5E26FF;
+}
+
+.c79 {
   word-wrap: break-word;
 }
 
-.c81 {
+.c83 {
   border-radius: 0px;
 }
 
-.c83 {
+.c85 {
   border-radius: 0px;
 }
 
@@ -6474,143 +6563,9 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
           >
             <div
               class="c51"
-              display="flex"
             >
               <div
-                class="c52"
-                display="flex"
-              >
-                <h4
-                  class="c53"
-                  color="core.nearblack"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Recipient
-                </h4>
-              </div>
-              <div
-                class="c54"
-                display="flex"
-                width="100%"
-              >
-                <input
-                  class="c55"
-                  display="inline-block"
-                  height="7"
-                  placeholder="t1..."
-                  value=""
-                  width="100%"
-                />
-                
-              </div>
-            </div>
-          </div>
-          
-          <div
-            class="c56"
-            display="flex"
-            label="Amount"
-            name="amount"
-          >
-            <div
-              class="c57"
-              color="input.border"
-              display="flex"
-              width="100%"
-            >
-              <h4
-                class="c53"
-                color="core.nearblack"
-                font-family="RT-Alias-Grotesk"
-                font-size="2"
-                font-weight="400"
-              >
-                Amount
-              </h4>
-            </div>
-            <div
-              class="c58"
-              display="inline-block"
-              width="100%"
-            >
-              <div
-                class="c59"
-                display="flex"
-                height="80px"
-                width="100%"
-              >
-                <div
-                  class="c60"
-                  display="flex"
-                  font-family="sansSerif"
-                  font-size="5"
-                  size="6"
-                >
-                  =
-                </div>
-                <input
-                  class="c61"
-                  display="inline-block"
-                  font-size="5"
-                  height="100%"
-                  label="Amount"
-                  name="amount"
-                  placeholder="0"
-                  step="0.000000000000000001"
-                  type="number"
-                  value=""
-                  width="100%"
-                />
-                <div
-                  class="c62"
-                  color="core.primary"
-                  display="flex"
-                  font-size="3"
-                  height="100%"
-                >
-                  FIL
-                </div>
-              </div>
-              <div
-                class="c63"
-                display="flex"
-                height="80px"
-              >
-                <input
-                  class="c61"
-                  display="inline-block"
-                  font-size="5"
-                  height="100%"
-                  min="0"
-                  placeholder="0"
-                  step="0.000000000000000001"
-                  type="number"
-                  value=""
-                  width="100%"
-                />
-                <div
-                  class="c62"
-                  color="core.primary"
-                  display="flex"
-                  font-size="3"
-                  height="100%"
-                >
-                  USD
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c64"
-            width="100%"
-          >
-            <div
-              class="c50"
-            >
-              <div
-                class="c51"
+                class="c41"
                 display="flex"
               >
                 <div
@@ -6624,37 +6579,173 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
                     font-size="2"
                     font-weight="400"
                   >
-                    Transaction Fee
+                    Recipient
                   </h4>
                 </div>
                 <div
                   class="c54"
                   display="flex"
-                  width="100%"
                 >
                   <input
-                    class="c65"
-                    disabled=""
+                    class="c55"
                     display="inline-block"
                     height="7"
-                    value="< 0.1"
+                    placeholder="t1..."
+                    value=""
+                    width="100%"
+                  />
+                  
+                </div>
+              </div>
+            </div>
+            
+            <div
+              class="c56"
+              display="flex"
+              label="Amount"
+              name="amount"
+            >
+              <div
+                class="c57"
+                color="input.border"
+                display="flex"
+                width="100%"
+              >
+                <h4
+                  class="c53"
+                  color="core.nearblack"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="2"
+                  font-weight="400"
+                >
+                  Amount
+                </h4>
+              </div>
+              <div
+                class="c58"
+                display="inline-block"
+                width="100%"
+              >
+                <div
+                  class="c59"
+                  display="flex"
+                  height="80px"
+                  width="100%"
+                >
+                  <div
+                    class="c60"
+                    display="flex"
+                    font-family="sansSerif"
+                    font-size="5"
+                    size="6"
+                  >
+                    =
+                  </div>
+                  <input
+                    class="c61"
+                    display="inline-block"
+                    font-size="5"
+                    height="100%"
+                    label="Amount"
+                    name="amount"
+                    placeholder="0"
+                    step="0.000000000000000001"
+                    type="number"
+                    value=""
                     width="100%"
                   />
                   <div
-                    class="c66"
+                    class="c62"
                     color="core.primary"
                     display="flex"
                     font-size="3"
-                    height="7"
+                    height="100%"
                   >
                     FIL
+                  </div>
+                </div>
+                <div
+                  class="c63"
+                  display="flex"
+                  height="80px"
+                >
+                  <input
+                    class="c64"
+                    display="inline-block"
+                    font-size="5"
+                    height="100%"
+                    min="0"
+                    placeholder="0"
+                    step="0.000000000000000001"
+                    type="number"
+                    value=""
+                    width="100%"
+                  />
+                  <div
+                    class="c65"
+                    color="core.primary"
+                    display="flex"
+                    font-size="3"
+                    height="100%"
+                  >
+                    USD
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="c66"
+              width="100%"
+            >
+              <div
+                class="c51"
+              >
+                <div
+                  class="c41"
+                  display="flex"
+                >
+                  <div
+                    class="c52"
+                    display="flex"
+                  >
+                    <h4
+                      class="c53"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Transaction Fee
+                    </h4>
+                  </div>
+                  <div
+                    class="c54"
+                    display="flex"
+                  >
+                    <input
+                      class="c67"
+                      disabled=""
+                      display="inline-block"
+                      height="7"
+                      value="< 0.1"
+                      width="100%"
+                    />
+                    <div
+                      class="c68"
+                      color="core.primary"
+                      display="flex"
+                      font-size="3"
+                      height="7"
+                    >
+                      FIL
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <button
-            class="c67"
+            class="c69"
             color="core.primary"
             display="flex"
             font-size="3"
@@ -6662,11 +6753,11 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
             type="button"
           >
             <div
-              class="c68"
+              class="c70"
               display="flex"
             >
               <p
-                class="c69 c70"
+                class="c71 c72"
                 font-family="RT-Alias-Grotesk"
                 font-size="3"
                 font-weight="400"
@@ -6674,7 +6765,8 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
                 ▼
               </p>
               <p
-                class="c71 c72"
+                class="c73 c74"
+                display="inline-block"
                 font-family="RT-Alias-Grotesk"
                 font-size="3"
                 font-weight="400"
@@ -6684,11 +6776,11 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
             </div>
           </button>
           <div
-            class="c73"
+            class="c75"
             display="flex"
           >
             <h2
-              class="c74"
+              class="c76"
               font-family="RT-Alias-Grotesk"
               font-size="4"
               font-weight="400"
@@ -6696,11 +6788,11 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
               Total
             </h2>
             <div
-              class="c75"
+              class="c77"
               display="flex"
             >
               <h2
-                class="c76 c77"
+                class="c78 c79"
                 color="core.primary"
                 font-family="RT-Alias-Grotesk"
                 font-size="5"
@@ -6711,7 +6803,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
                 FIL
               </h2>
               <h2
-                class="c78"
+                class="c80"
                 color="core.darkgray"
                 font-family="RT-Alias-Grotesk"
                 font-size="4"
@@ -6725,17 +6817,17 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
           </div>
         </div>
         <div
-          class="c79"
+          class="c81"
         >
           <button
-            class="c80 c81 Sendjs___StyledButton-sc-1crplc1-6 c81"
+            class="c82 c83 Sendjs___StyledButton-sc-1crplc1-6 c83"
             font-size="3"
             type="button"
           >
             Back
           </button>
           <button
-            class="c82 c83 Sendjs___StyledButton2-sc-1crplc1-7 c83"
+            class="c84 c85 Sendjs___StyledButton2-sc-1crplc1-7 c85"
             font-size="3"
             type="submit"
           >

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -5203,7 +5203,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   position: absolute;
   left: -24px;
   bottom: -24px;
-  z-index: 999;
+  z-index: 99;
   border-radius: 32px;
   padding-bottom: 4px;
   background-color: #ffffff;
@@ -5229,10 +5229,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   min-width: 0;
   box-sizing: border-box;
   position: relative;
-  border-top: 1px solid;
-  border-color: #EFF3FD;
   border-radius: 4px;
-  background-color: #d1ddfa;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5685,7 +5682,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   font-size: 1.125rem;
   text-align: right;
   cursor: text;
-  background-color: #EFF3FD;
+  background: transparent;
   padding-left: 16px;
   padding-right: 16px;
   display: inline-block;
@@ -5721,7 +5718,6 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-top-right-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5749,10 +5745,8 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   top: 0px;
   left: 0px;
   border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: #d1ddfa;
   color: #5E26FF;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5772,6 +5766,33 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   text-align: center;
   position: relative;
   background: #d1ddfa;
+}
+
+.c68 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: transparent;
+  color: #5E26FF;
+  height: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: core.transparent;
 }
 
 .c61 {
@@ -5796,7 +5817,6 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-top-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -5839,7 +5859,6 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   border-bottom-left-radius: 4px;
   border: 0;
   border-color: #999999;
-  background: #d1ddfa;
   -moz-appearance: textfield;
 }
 
@@ -5858,34 +5877,6 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
 .c64::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c68 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  background-color: #d1ddfa;
-  height: 64px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #d1ddfa;
-  background-color: transparent;
 }
 
 .c81 {

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -315,6 +315,7 @@ exports[`WalletView it renders correctly 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
+  overflow: hidden;
   margin: 0;
 }
 
@@ -966,6 +967,7 @@ exports[`WalletView it renders correctly 1`] = `
             font-family="RT-Alias-Grotesk"
             font-size="5"
             font-weight="1"
+            overflow="hidden"
           >
             t1z22 ... 6wgi
           </h2>
@@ -4054,6 +4056,7 @@ exports[`WalletView it renders the receive flow when a user clicks receive 1`] =
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
+  overflow: hidden;
   margin: 0;
 }
 
@@ -4534,6 +4537,7 @@ exports[`WalletView it renders the receive flow when a user clicks receive 1`] =
             font-family="RT-Alias-Grotesk"
             font-size="5"
             font-weight="1"
+            overflow="hidden"
           >
             t1z22 ... 6wgi
           </h2>
@@ -5428,6 +5432,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
+  overflow: hidden;
   margin: 0;
 }
 
@@ -6281,6 +6286,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
             font-family="RT-Alias-Grotesk"
             font-size="5"
             font-weight="1"
+            overflow="hidden"
           >
             t1z22 ... 6wgi
           </h2>


### PR DESCRIPTION
# Changes
1. Numerous small styling updates to the `SendCard`'s `Input` components.
1. Replaced the global padding on `SendCard` with local padding on its child containers to allow us to implement the cleaner `GasCustomization styling:

## Send Card
![image](https://user-images.githubusercontent.com/6787950/84397694-57f0bd00-abd5-11ea-8adb-7d4789de7a5c.png)

## Send Card, Expanded
![image](https://user-images.githubusercontent.com/6787950/84397737-69d26000-abd5-11ea-81d6-48992d3bd5a5.png)
