### PR TITLE
Fixes TruncatedAddress overflow

### DIFF
--- a/components/Shared/AccountCard/index.jsx
+++ b/components/Shared/AccountCard/index.jsx
@@ -82,7 +82,13 @@ const AccountCard = forwardRef(
         <Box color='card.account.color'>
           <BigTitle>{alias}</BigTitle>
           <Box display='flex' alignContent='center'>
-            <AccountAddress fontWeight={1} fontSize={5} margin={0}>
+            <AccountAddress
+              fontWeight={1}
+              fontSize={5}
+              margin={0}
+              overflow='hidden'
+              whiteSpace='nowrap'
+            >
               {truncate(address)}
             </AccountAddress>
             <CopyAddress


### PR DESCRIPTION
# Changes
`AccountAddress` no longer wraps to a second line. If it does overflow its container (highly unlikely) it is hidden.

### UX Concern
Although highly unlikely that an address is wide enough to have even one whole letter obscured (hidden), even a partially hidden letter is not "great" UX as it may cause confusion.

### Possible Alternative
We dynamically size it if it is in danger of overflowing.

### Reference
![image](https://user-images.githubusercontent.com/6787950/84398813-c8e4a480-abd6-11ea-8782-4b14d7fda0f1.png)
