### PR TITLE
Feat/fix account info484

### DIFF
--- a/components/Msig/Home/AccountInfo.jsx
+++ b/components/Msig/Home/AccountInfo.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
@@ -13,10 +12,6 @@ import {
   Title as AccountAddress
 } from '../../Shared'
 import truncateAddress from '../../../utils/truncateAddress'
-
-const ViewAddress = styled(Button)`
-  padding: 0;
-`
 
 const AccountInfo = ({
   msigAddress,
@@ -111,8 +106,10 @@ const AccountInfo = ({
                     <AccountAddress m={0}>
                       {truncateAddress(walletAddress)}
                     </AccountAddress>
-                    <ViewAddress
+                    <Button
                       height='auto'
+                      py={0}
+                      px={0}
                       border={0}
                       type='button'
                       variant='secondary'

--- a/components/Msig/Home/AccountInfo.jsx
+++ b/components/Msig/Home/AccountInfo.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
@@ -12,6 +13,10 @@ import {
   Title as AccountAddress
 } from '../../Shared'
 import truncateAddress from '../../../utils/truncateAddress'
+
+const ViewAddress = styled(Button)`
+  padding: 0;
+`
 
 const AccountInfo = ({
   msigAddress,
@@ -51,10 +56,7 @@ const AccountInfo = ({
             <Glyph mr={3} color='card.account.color' acronym='Ms' />
             <Box flexGrow='1' color='card.account.color'>
               <Text m={0}>Multisig Account</Text>
-              <CopyAddress
-                justifyContent='space-between'
-                address={msigAddress}
-              />
+              <CopyAddress address={msigAddress} />
             </Box>
           </Box>
         </Box>
@@ -98,7 +100,7 @@ const AccountInfo = ({
                     fill='#444'
                   />
                 </Box>
-                <Box display='flex' flexDirection='column'>
+                <Box display='flex' flexDirection='column' height={6}>
                   <Text m={0}>Linked to Ledger Device</Text>
                   <Box
                     display='flex'
@@ -109,8 +111,8 @@ const AccountInfo = ({
                     <AccountAddress m={0}>
                       {truncateAddress(walletAddress)}
                     </AccountAddress>
-                    <Button
-                      p={0}
+                    <ViewAddress
+                      height='auto'
                       border={0}
                       type='button'
                       variant='secondary'

--- a/components/Shared/AccountCard/__snapshots__/index.test.js.snap
+++ b/components/Shared/AccountCard/__snapshots__/index.test.js.snap
@@ -220,6 +220,7 @@ exports[`AccountCard renders the card 1`] = `
   align-items: center;
   border-width: 1px;
   border-radius: 4px;
+  height: auto;
   opacity: 1 !important;
   border: 0;
   background: transparent;
@@ -568,6 +569,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   align-items: center;
   border-width: 1px;
   border-radius: 4px;
+  height: auto;
   opacity: 1 !important;
   border: 0;
   background: transparent;

--- a/components/Shared/Copy/index.jsx
+++ b/components/Shared/Copy/index.jsx
@@ -10,6 +10,7 @@ import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
 const Copy = styled(BaseButton)`
   /* !important is declared here to override BaseButton's opacity:0.8 on hover. The only instance of us using this declaration. */
+  height: auto;
   opacity: 1 !important;
   border: 0;
   background: transparent;

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -504,6 +504,7 @@ exports[`WalletView it renders correctly 1`] = `
   align-items: center;
   border-width: 1px;
   border-radius: 4px;
+  height: auto;
   opacity: 1 !important;
   border: 0;
   background: transparent;
@@ -4485,6 +4486,7 @@ exports[`WalletView it renders the send flow when a user clicks send 1`] = `
   align-items: center;
   border-width: 1px;
   border-radius: 4px;
+  height: auto;
   opacity: 1 !important;
   border: 0;
   background: transparent;


### PR DESCRIPTION
Resolves #484 

# Details
The issue was largely to do with inheritance of the `BaseButton`'s new explicit `height` property. We want an explicit height in 95% of use cases but this is one where we do not.

# Ref
<img width="338" alt="Screen Shot 2020-09-09 at 3 40 42 PM" src="https://user-images.githubusercontent.com/6787950/92639899-da5f4a80-f2b2-11ea-8989-0c037d41f73c.png">
