### PR TITLE
 Replace Withdraw flow fixed footer w/ flex-based sticky footer

### DIFF
--- a/components/Msig/Home/State.jsx
+++ b/components/Msig/Home/State.jsx
@@ -35,7 +35,7 @@ const State = ({
     resetState()
   }
   return (
-    <Box display='flex' flexDirection='row' minHeight='100vh'>
+    <Box display='flex' flexDirection='row' minHeight='100vh' width='100%'>
       <AccountInfo
         msigAddress={msigAddress}
         walletAddress={walletAddress}

--- a/components/Msig/Home/index.jsx
+++ b/components/Msig/Home/index.jsx
@@ -18,7 +18,7 @@ export default () => {
   const [childView, setChildView] = useState(MSIG_STATE)
   return (
     <>
-      <Box minHeight='100vh' p={3}>
+      <Box display='flex' width='100%' minHeight='100vh' p={3}>
         {childView === MSIG_STATE && (
           <State
             msigAddress={msigActorAddress}

--- a/components/Msig/Withdraw/index.jsx
+++ b/components/Msig/Withdraw/index.jsx
@@ -167,15 +167,16 @@ const Withdrawing = ({ address, balance, close }) => {
       <Box
         width='100%'
         display='flex'
+        flex='1'
         flexDirection='column'
         alignItems='center'
-        mb={7}
       >
         <Box
           maxWidth={14}
           width={13}
           minWidth={12}
           display='flex'
+          flex='1'
           flexDirection='column'
           justifyContent='space-between'
         >
@@ -326,13 +327,11 @@ const Withdrawing = ({ address, balance, close }) => {
 
           <Box
             display='flex'
+            flex='1'
             flexDirection='row'
             justifyContent='space-between'
-            position='fixed'
-            bottom='3'
+            alignItems='flex-end'
             margin='auto'
-            left='0'
-            right='0'
             maxWidth={14}
             width={13}
             minWidth={12}


### PR DESCRIPTION
Resolves #486 

Used flex's `flex-grow` to push the progress buttons down to the bottom of the screen