### PR TITLE
Update tutorial links to point to Glif blog

### DIFF
--- a/components/Investor/Landing.jsx
+++ b/components/Investor/Landing.jsx
@@ -146,7 +146,7 @@ export default () => {
                 fontSize={2}
                 my={3}
                 target='_blank'
-                href='https://paper.dropbox.com/doc/Self-Custodied-SAFT-Guide--A65usBCOBC6H0c2e_JUleP63Ag-dHxZu59oAeSw03RrRpCrd'
+                href='https://reading.supply/@glif/self-custodied-saft-guide-pXi808'
                 rel='noopener'
               >
                 Need help? Follow along with this guided tutorial.

--- a/components/Onboarding/Configure/Ledger/Step2.jsx
+++ b/components/Onboarding/Configure/Ledger/Step2.jsx
@@ -79,9 +79,10 @@ const Step2Helper = ({
           <Text>Please unlock your Ledger device.</Text>
           <Text>And make sure the Filecoin App is open</Text>
           <StyledATag
+            fontSize={2}
             target='_blank'
             rel='noopener noreferrer'
-            href='https://paper.dropbox.com/doc/Install-the-Filecoin-App-on-your-Ledger-Device--A7wuBpET2_FTgmjTLebkfmSAAg-FFy4WD4kcYPNjuw4V1PQF'
+            href='https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX'
           >
             Click here for installation instructions.
           </StyledATag>

--- a/components/Onboarding/Configure/Ledger/__snapshots__/index.test.js.snap
+++ b/components/Onboarding/Configure/Ledger/__snapshots__/index.test.js.snap
@@ -3458,7 +3458,7 @@ exports[`Ledger configuration Step2 it renders msig step2 correctly, with the ri
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c16:hover {
@@ -3604,8 +3604,8 @@ exports[`Ledger configuration Step2 it renders msig step2 correctly, with the ri
       <a
         class="c16"
         color="core.primary"
-        font-size="3"
-        href="https://paper.dropbox.com/doc/Install-the-Filecoin-App-on-your-Ledger-Device--A7wuBpET2_FTgmjTLebkfmSAAg-FFy4WD4kcYPNjuw4V1PQF"
+        font-size="2"
+        href="https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -3819,7 +3819,7 @@ exports[`Ledger configuration Step2 it renders normal wallet step2 correctly, wi
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c15:hover {
@@ -3954,8 +3954,8 @@ exports[`Ledger configuration Step2 it renders normal wallet step2 correctly, wi
       <a
         class="c15"
         color="core.primary"
-        font-size="3"
-        href="https://paper.dropbox.com/doc/Install-the-Filecoin-App-on-your-Ledger-Device--A7wuBpET2_FTgmjTLebkfmSAAg-FFy4WD4kcYPNjuw4V1PQF"
+        font-size="2"
+        href="https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -4181,7 +4181,7 @@ exports[`Ledger configuration Step2 it renders premainnet saft step2 correctly, 
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c16:hover {
@@ -4349,8 +4349,8 @@ exports[`Ledger configuration Step2 it renders premainnet saft step2 correctly, 
       <a
         class="c16"
         color="core.primary"
-        font-size="3"
-        href="https://paper.dropbox.com/doc/Install-the-Filecoin-App-on-your-Ledger-Device--A7wuBpET2_FTgmjTLebkfmSAAg-FFy4WD4kcYPNjuw4V1PQF"
+        font-size="2"
+        href="https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX"
         rel="noopener noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
Resolves #547 

@Schwartz10 This updates the links for the **Self Custodied SAFT Guide** and the **Filecoin app installation on your Ledger device** guide. 

I also took the liberty to update the link fontSize on that second link to match the other text on the screen.