### PR TITLE
Integrate new AccountSummary component

### DIFF
--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -27,30 +27,30 @@ const AccountSummary = ({
       flexDirection='column'
       justifyContent='center'
       alignItems='center'
-      boxShadow={2}
-      borderRadius={3}
-      maxWidth={11}
+      mb={1}
     >
-      <Box
-        display='flex'
-        flexDirection='column'
-        width={11}
-        height={8}
-        borderTopLeftRadius={3}
-        borderTopRightRadius={3}
-        p={3}
-        color='card.account.color'
-        bg='card.account.background'
-      >
+      <Box display='flex' color='card.account.color'>
+        <Glyph
+          mr={3}
+          color='core.nearblack'
+          acronym='Ms'
+          border={1}
+          css={`
+            transform: translateY(6px);
+          `}
+        />
         <Box
           display='flex'
           alignItems='center'
           justifyContent='flex-start'
-          color='card.account.color'
+          color='core.darkgray'
+          bg='core.lightgray'
+          p={2}
+          borderRadius={2}
+          width={11}
+          height='40px'
         >
-          <Glyph mr={3} color='card.account.color' acronym='Ms' />
-          <Box flexGrow='1' color='card.account.color'>
-            <Text m={0}>Multisig Account</Text>
+          <Box flexGrow='1'>
             <CopyAddress address={msigAddress} />
           </Box>
         </Box>
@@ -59,11 +59,9 @@ const AccountSummary = ({
         display='flex'
         flexDirection='column'
         justifyContent='space-between'
-        width={11}
         height='auto'
         borderBottomLeftRadius={3}
         borderBottomRightRadius={3}
-        p={3}
       >
         {error ? (
           <>
@@ -85,7 +83,37 @@ const AccountSummary = ({
           </>
         ) : (
           <>
-            <Box display='flex' flexDirection='row'>
+            <Box display='flex' color='card.account.color' mt={1}>
+              <Glyph
+                mr={3}
+                Icon={IconLedger}
+                color='core.nearblack'
+                bg='core.white'
+                fill='#444'
+                borderRadius={6}
+                border={1}
+                css='transform:translateY(-6px)'
+              />
+              <Box
+                display='flex'
+                alignItems='center'
+                justifyContent='flex-start'
+                color='core.darkgray'
+                bg='core.lightgray'
+                p={2}
+                borderRadius={2}
+                width={11}
+                height='40px'
+              >
+                <Box flexGrow='1'>
+                  <AccountAddress m={0}>
+                    {truncateAddress(walletAddress)}
+                  </AccountAddress>
+                </Box>
+              </Box>
+            </Box>
+
+            {/* <Box display='flex' flexDirection='row'>
               <Box>
                 {' '}
                 <Glyph
@@ -95,8 +123,7 @@ const AccountSummary = ({
                   fill='#444'
                 />
               </Box>
-              <Box display='flex' flexDirection='column' height={6}>
-                <Text m={0}>Linked to Ledger Device</Text>
+              <Box display='flex' flexDirection='column' height={5}>
                 <Box
                   display='flex'
                   justifyContent='space-between'
@@ -120,7 +147,7 @@ const AccountSummary = ({
                   />
                 </Box>
               </Box>
-            </Box>
+            </Box> */}
           </>
         )}
       </Box>

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -27,18 +27,9 @@ const AccountSummary = ({
       flexDirection='column'
       justifyContent='center'
       alignItems='center'
-      mb={1}
     >
       <Box display='flex' color='card.account.color'>
-        <Glyph
-          mr={3}
-          color='core.nearblack'
-          acronym='Ms'
-          border={1}
-          css={`
-            transform: translateY(6px);
-          `}
-        />
+        <Glyph mr={3} color='core.nearblack' acronym='Ms' border={1} />
         <Box
           display='flex'
           alignItems='center'
@@ -83,7 +74,7 @@ const AccountSummary = ({
           </>
         ) : (
           <>
-            <Box display='flex' color='card.account.color' mt={1}>
+            <Box position='relative' display='flex' color='card.account.color'>
               <Glyph
                 mr={3}
                 Icon={IconLedger}

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -9,7 +9,7 @@ import {
   Text,
   Button,
   IconLedger,
-  Title as AccountAddress
+  ButtonViewAddress
 } from '../../Shared'
 import truncateAddress from '../../../utils/truncateAddress'
 
@@ -106,10 +106,9 @@ const AccountSummary = ({
                 height='40px'
               >
                 <Box flexGrow='1'>
-                  <AccountAddress m={0}>
-                    {truncateAddress(walletAddress)}
-                  </AccountAddress>
+                  <CopyAddress address={truncateAddress(walletAddress)} />
                 </Box>
+                <ButtonViewAddress />
               </Box>
             </Box>
 

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -1,0 +1,144 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+
+import {
+  Box,
+  Glyph,
+  CopyAddress,
+  Text,
+  Button,
+  IconLedger,
+  Title as AccountAddress
+} from '../../Shared'
+import truncateAddress from '../../../utils/truncateAddress'
+
+const AccountSummary = ({
+  msigAddress,
+  showOnDevice,
+  walletAddress,
+  reset,
+  ledgerBusy,
+  error
+}) => {
+  return (
+    <Box
+      display='flex'
+      flexDirection='column'
+      justifyContent='center'
+      alignItems='center'
+      boxShadow={2}
+      borderRadius={3}
+      maxWidth={11}
+    >
+      <Box
+        display='flex'
+        flexDirection='column'
+        width={11}
+        height={8}
+        borderTopLeftRadius={3}
+        borderTopRightRadius={3}
+        p={3}
+        color='card.account.color'
+        bg='card.account.background'
+      >
+        <Box
+          display='flex'
+          alignItems='center'
+          justifyContent='flex-start'
+          color='card.account.color'
+        >
+          <Glyph mr={3} color='card.account.color' acronym='Ms' />
+          <Box flexGrow='1' color='card.account.color'>
+            <Text m={0}>Multisig Account</Text>
+            <CopyAddress address={msigAddress} />
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        display='flex'
+        flexDirection='column'
+        justifyContent='space-between'
+        width={11}
+        height='auto'
+        borderBottomLeftRadius={3}
+        borderBottomRightRadius={3}
+        p={3}
+      >
+        {error ? (
+          <>
+            <Box display='flex' flexDirection='row'>
+              <IconLedger />
+              <Text m={0} ml={2} lineHeight='2'>
+                Error
+              </Text>
+            </Box>
+            <Box display='flex' flexDirection='column'>
+              <Text color='core.primary'>{error}</Text>
+              <Button
+                type='button'
+                variant='secondary'
+                title='Retry'
+                onClick={reset}
+              />
+            </Box>
+          </>
+        ) : (
+          <>
+            <Box display='flex' flexDirection='row'>
+              <Box>
+                {' '}
+                <Glyph
+                  mr={3}
+                  Icon={IconLedger}
+                  color='core.nearblack'
+                  fill='#444'
+                />
+              </Box>
+              <Box display='flex' flexDirection='column' height={6}>
+                <Text m={0}>Linked to Ledger Device</Text>
+                <Box
+                  display='flex'
+                  justifyContent='space-between'
+                  alignItems='center'
+                  flexGrow='1'
+                >
+                  <AccountAddress m={0}>
+                    {truncateAddress(walletAddress)}
+                  </AccountAddress>
+                  <Button
+                    height='auto'
+                    py={0}
+                    px={0}
+                    border={0}
+                    type='button'
+                    variant='secondary'
+                    title='View'
+                    color='core.primary'
+                    disabled={ledgerBusy}
+                    onClick={showOnDevice}
+                  />
+                </Box>
+              </Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+AccountSummary.propTypes = {
+  msigAddress: ADDRESS_PROPTYPE,
+  walletAddress: ADDRESS_PROPTYPE,
+  showOnDevice: PropTypes.func.isRequired,
+  ledgerBusy: PropTypes.bool.isRequired,
+  error: PropTypes.string,
+  reset: PropTypes.func.isRequired
+}
+
+AccountSummary.defaultProps = {
+  error: ''
+}
+
+export default AccountSummary

--- a/components/Msig/Home/State.jsx
+++ b/components/Msig/Home/State.jsx
@@ -6,7 +6,7 @@ import {
   FILECOIN_NUMBER_PROP
 } from '../../../customPropTypes'
 import { Box, Button, Title, Text, Menu, MenuItem } from '../../Shared'
-import AccountInfo from './AccountInfo'
+import AccountSummary from './AccountSummary'
 import useWallet from '../../../WalletProvider/useWallet'
 import { useWalletProvider } from '../../../WalletProvider'
 import { reportLedgerConfigError } from '../../../utils/ledger/reportLedgerConfigError'
@@ -79,7 +79,7 @@ const State = ({
           </Menu>
         </MenuItem>
         <MenuItem>
-          <AccountInfo
+          <AccountSummary
             msigAddress={msigAddress}
             walletAddress={walletAddress}
             showOnDevice={onShowOnLedger}

--- a/components/Shared/IconButtons/index.jsx
+++ b/components/Shared/IconButtons/index.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import styled from 'styled-components'
 import { func, object } from 'prop-types'
 import { layout, space, border, flexbox, position } from 'styled-system'
-import { IconClose, IconCopyAccountAddress } from '../Icons'
+import { IconClose, IconCopyAccountAddress, IconViewAddress } from '../Icons'
 
 const IconButtonBase = styled.button`
   outline: 0;
@@ -38,4 +38,8 @@ export const ButtonClose = ({ ...props }) => (
 
 export const ButtonCopyAccountAddress = ({ ...props }) => (
   <IconButton Icon={IconCopyAccountAddress} {...props} />
+)
+
+export const ButtonViewAddress = ({ ...props }) => (
+  <IconButton Icon={IconViewAddress} {...props} />
 )

--- a/components/Shared/Icons/index.jsx
+++ b/components/Shared/Icons/index.jsx
@@ -352,16 +352,16 @@ export const IconViewAddress = forwardRef((props, ref) => (
     ref={ref}
     {...props}
   >
-    <rect x='4' y='4' width='16' height='16' rx='8' fill='white' />
+    <rect width='24' height='24' rx='12' fill='white' />
     <rect
       opacity='0.5'
-      x='7'
-      y='8'
-      width='8'
-      height='8'
-      rx='4'
+      x='4.5'
+      y='7.5'
+      width='12'
+      height='12'
+      rx='6'
       fill='#0A0A0A'
     />
-    <rect x='9' y='10' width='4' height='4' rx='2' fill='#0A0A0A' />
+    <rect x='7.5' y='10.5' width='6' height='6' rx='3' fill='#0A0A0A' />
   </IconBase>
 ))

--- a/components/Shared/Icons/index.jsx
+++ b/components/Shared/Icons/index.jsx
@@ -341,3 +341,27 @@ export const IconLedger = forwardRef((props, ref) => (
     />
   </IconBase>
 ))
+
+export const IconViewAddress = forwardRef((props, ref) => (
+  <IconBase
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    ref={ref}
+    {...props}
+  >
+    <rect x='4' y='4' width='16' height='16' rx='8' fill='white' />
+    <rect
+      opacity='0.5'
+      x='7'
+      y='8'
+      width='8'
+      height='8'
+      rx='4'
+      fill='#0A0A0A'
+    />
+    <rect x='9' y='10' width='4' height='4' rx='2' fill='#0A0A0A' />
+  </IconBase>
+))


### PR DESCRIPTION
# Changes

1. Cloned `AccountInfo` (we may want to use it as-is e.g. in the wallet proper so I've opted to keep it for the time being) and turned it into `AccountSummary`
1. Created `IconViewAddress`
1. Created `ButtonViewAddress`

# Ref
![image](https://user-images.githubusercontent.com/6787950/94179601-1b3e8e00-fe73-11ea-9efd-17e291faffd4.png)
