### PR TITLE
Update withdrawal flow

### DIFF
--- a/components/Msig/Withdraw/index.jsx
+++ b/components/Msig/Withdraw/index.jsx
@@ -254,7 +254,7 @@ const Withdrawing = ({ address, balance, close }) => {
                   value={toAddress}
                   onChange={e => setToAddress(e.target.value)}
                   error={toAddressError}
-                  disabled={step === 2}
+                  disabled={step >= 2}
                   onFocus={() => {
                     if (toAddressError) setToAddressError('')
                   }}

--- a/components/Msig/Withdraw/index.jsx
+++ b/components/Msig/Withdraw/index.jsx
@@ -18,7 +18,8 @@ import {
   IconLedger,
   Num,
   Title,
-  Form
+  Form,
+  Card
 } from '../../Shared'
 import {
   ADDRESS_PROPTYPE,
@@ -216,13 +217,29 @@ const Withdrawing = ({ address, balance, close }) => {
             {!attemptingTx &&
               !hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
                 <>
-                  <StepHeader
-                    title='Withdrawing Filecoin'
-                    currentStep={step}
-                    totalSteps={4}
-                    glyphAcronym='Wd'
-                  />
-                  <WithdrawHeaderText step={step} customizingGas={false} />
+                  <Card
+                    display='flex'
+                    flexDirection='column'
+                    justifyContent='space-between'
+                    border='none'
+                    width='auto'
+                    my={2}
+                    backgroundColor='blue.muted700'
+                  >
+                    <StepHeader
+                      title='Withdrawing Filecoin'
+                      currentStep={step}
+                      totalSteps={4}
+                      glyphAcronym='Wd'
+                    />
+                    <Box mt={6} mb={4}>
+                      <WithdrawHeaderText
+                        my={0}
+                        step={step}
+                        customizingGas={false}
+                      />
+                    </Box>
+                  </Card>
                 </>
               )}
             <Box boxShadow={2} borderRadius={4}>
@@ -265,20 +282,23 @@ const Withdrawing = ({ address, balance, close }) => {
                     display='flex'
                     flexDirection='row'
                     justifyContent='space-between'
+                    alignItems='center'
                     width='100%'
                     p={3}
                     border={0}
                     bg='background.screen'
                   >
-                    <Text margin={0}>Transaction Fee</Text>
-                    <Box display='flex' alignItems='center'>
-                      <Text margin={0} color='core.darkgray'>
-                        Paid via
-                      </Text>
-                      <IconLedger height='32px' />{' '}
-                      <Text margin={0} color='core.darkgray'>
-                        {makeFriendlyBalance(wallet.balance, 2, true)} FIL
-                      </Text>
+                    <Box display='flex' flexDirection='column'>
+                      <Text margin={0}>Transaction Fee</Text>
+                      <Box display='flex' alignItems='center'>
+                        <Text margin={0} color='core.darkgray'>
+                          Paid via
+                        </Text>
+                        <IconLedger height='32px' />{' '}
+                        <Text margin={0} color='core.darkgray'>
+                          {makeFriendlyBalance(wallet.balance, 2, true)} FIL
+                        </Text>
+                      </Box>
                     </Box>
                     <Text ml={2} color='core.primary'>
                       {'< 0.0001 FIL'}
@@ -331,6 +351,7 @@ const Withdrawing = ({ address, balance, close }) => {
             maxWidth={14}
             width={13}
             minWidth={12}
+            mt={4}
           >
             <Button
               title='Back'


### PR DESCRIPTION
# Changes
1. Added `margin-top` to progress button flex container
1. Added `Card` element and styling around the `HelperText` to match its styling w/ what we've done in the traditional `Send` flow
1. Wrapped the Transaction Fee & Paid by Ledger elements to occupy two rows.
1. Disable `Recipient` input outside of Step 2

# Ref
![image](https://user-images.githubusercontent.com/6787950/94581052-ff5f3180-0250-11eb-8f6b-f38012ac2551.png)
