### PR TITLE
Feat/button maxheight

### DIFF
--- a/components/Msig/ChangeOwner/index.jsx
+++ b/components/Msig/ChangeOwner/index.jsx
@@ -16,6 +16,7 @@ import {
   Input,
   Text,
   IconLedger,
+  InlineBox,
   Form
 } from '../../Shared'
 import {
@@ -163,150 +164,161 @@ const ChangeOwner = ({ address, balance, close }) => {
 
   return (
     <>
-      <ButtonClose
-        role='button'
-        type='button'
-        position='fixed'
-        top='3'
-        right='3'
-        onClick={() => {
-          setAttemptingTx(false)
-          setUncaughtError('')
-          resetLedgerState()
-          close()
-        }}
-      />
-      <Form onSubmit={onSubmit}>
-        <Box
-          maxWidth={14}
-          width={13}
-          minWidth={12}
-          display='flex'
-          flexDirection='column'
-          justifyContent='space-between'
-        >
-          <Box>
-            {hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
-              <ErrorCard
-                error={reportLedgerConfigError({
-                  ...ledger,
-                  otherError: uncaughtError
-                })}
-                reset={() => {
+      <Box display='flex' flexDirection='column' width='100%'>
+        <ButtonClose
+          role='button'
+          type='button'
+          justifySelf='flex-end'
+          marginLeft='auto'
+          onClick={() => {
+            setAttemptingTx(false)
+            setUncaughtError('')
+            resetLedgerState()
+            close()
+          }}
+        />
+        <Form onSubmit={onSubmit}>
+          <Box
+            maxWidth={13}
+            width='100%'
+            minWidth={11}
+            display='flex'
+            flexDirection='column'
+            justifyContent='flex-start'
+            flexGrow='1'
+          >
+            <Box>
+              {hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
+                <ErrorCard
+                  error={reportLedgerConfigError({
+                    ...ledger,
+                    otherError: uncaughtError
+                  })}
+                  reset={() => {
+                    setAttemptingTx(false)
+                    setUncaughtError('')
+                    resetLedgerState()
+                    setStep(2)
+                  }}
+                />
+              )}
+              {attemptingTx && (
+                <ConfirmationCard
+                  loading={fetchingTxDetails || mPoolPushing}
+                  walletType={LEDGER}
+                  currentStep={4}
+                  totalSteps={4}
+                  msig
+                />
+              )}
+              {!attemptingTx &&
+                !hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
+                  <>
+                    <StepHeader
+                      title='Change Ownership'
+                      currentStep={step}
+                      totalSteps={4}
+                      glyphAcronym='Ch'
+                    />
+                    <ChangeOwnerHeaderText step={step} />
+                  </>
+                )}
+              {step === 1 && <Preface />}
+              <Box boxShadow={2} borderRadius={4}>
+                {step > 1 && (
+                  <CardHeader
+                    address={address}
+                    balance={balance}
+                    customizingGas={false}
+                  />
+                )}
+                {step > 1 && (
+                  <>
+                    <Box width='100%' p={3} border={0} bg='background.screen'>
+                      <Input.Address
+                        label='New owner'
+                        value={toAddress}
+                        onChange={e => setToAddress(e.target.value)}
+                        error={toAddressError}
+                        disabled={step === 3}
+                        onFocus={() => {
+                          if (toAddressError) setToAddressError('')
+                        }}
+                      />
+                    </Box>
+                    {step > 2 && (
+                      <Box
+                        display='flex'
+                        flexDirection='row'
+                        justifyContent='space-between'
+                        width='100%'
+                        p={3}
+                        border={0}
+                        bg='background.screen'
+                      >
+                        <Box>
+                          <Text margin={0}>Transaction Fee</Text>
+                          <Box display='flex' alignItems='flex-start'>
+                            <Text margin={0} color='core.darkgray'>
+                              Paid via{' '}
+                            </Text>
+                            <InlineBox ml={1} mr={2}>
+                              <IconLedger size={4} />
+                            </InlineBox>
+                            <Text margin={0} color='core.darkgray'>
+                              {makeFriendlyBalance(wallet.balance, 6, true)} FIL
+                            </Text>
+                          </Box>
+                        </Box>
+                        <Box display='flex' flexDirection='row'>
+                          <Text ml={2} color='core.primary'>
+                            {'< 0.0001 FIL'}
+                          </Text>
+                        </Box>
+                      </Box>
+                    )}
+                  </>
+                )}
+              </Box>
+            </Box>
+            <Box
+              display='flex'
+              flex='1'
+              flexDirection='row'
+              justifyContent='space-between'
+              alignItems='flex-end'
+              margin='auto'
+              maxWidth={13}
+              width='100%'
+              minWidth={11}
+              maxHeight={12}
+              my={3}
+            >
+              <Button
+                title='Back'
+                variant='secondary'
+                onClick={() => {
                   setAttemptingTx(false)
                   setUncaughtError('')
                   resetLedgerState()
-                  setStep(2)
+                  if (step === 1) {
+                    close()
+                  } else {
+                    setStep(step - 1)
+                  }
                 }}
+                disabled={attemptingTx}
               />
-            )}
-            {attemptingTx && (
-              <ConfirmationCard
-                loading={fetchingTxDetails || mPoolPushing}
-                walletType={LEDGER}
-                currentStep={4}
-                totalSteps={4}
-                msig
+              <Button
+                variant='primary'
+                title='Next'
+                disabled={isSubmitBtnDisabled()}
+                type='submit'
               />
-            )}
-            {!attemptingTx &&
-              !hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
-                <>
-                  <StepHeader
-                    title='Change Ownership'
-                    currentStep={step}
-                    totalSteps={4}
-                    glyphAcronym='Ch'
-                  />
-                  <ChangeOwnerHeaderText step={step} />
-                </>
-              )}
-            {step === 1 && <Preface />}
-            {step > 1 && (
-              <CardHeader
-                address={address}
-                balance={balance}
-                customizingGas={false}
-              />
-            )}
-            {step > 1 && (
-              <>
-                <Box width='100%' p={3} border={0} bg='background.screen'>
-                  <Input.Address
-                    label='New owner'
-                    value={toAddress}
-                    onChange={e => setToAddress(e.target.value)}
-                    error={toAddressError}
-                    disabled={step === 3}
-                    onFocus={() => {
-                      if (toAddressError) setToAddressError('')
-                    }}
-                  />
-                </Box>
-                {step > 2 && (
-                  <Box
-                    display='flex'
-                    flexDirection='row'
-                    justifyContent='space-between'
-                    width='100%'
-                    p={3}
-                    border={0}
-                    bg='background.screen'
-                  >
-                    <Box>
-                      <Text margin={0}>Transaction Fee</Text>
-                      <Text margin={0} color='core.darkgray'>
-                        Paid via <IconLedger />{' '}
-                        {makeFriendlyBalance(wallet.balance, 6, true)} FIL
-                      </Text>
-                    </Box>
-                    <Box display='flex' flexDirection='row'>
-                      <Text ml={2} color='core.primary'>
-                        {'< 0.0001 FIL'}
-                      </Text>
-                    </Box>
-                  </Box>
-                )}
-              </>
-            )}
+            </Box>
           </Box>
-          <Box
-            display='flex'
-            flexDirection='row'
-            justifyContent='space-between'
-            position='fixed'
-            bottom='3'
-            margin='auto'
-            left='0'
-            right='0'
-            maxWidth={14}
-            width={13}
-            minWidth={12}
-          >
-            <Button
-              title='Back'
-              variant='secondary'
-              onClick={() => {
-                setAttemptingTx(false)
-                setUncaughtError('')
-                resetLedgerState()
-                if (step === 1) {
-                  close()
-                } else {
-                  setStep(step - 1)
-                }
-              }}
-              disabled={attemptingTx}
-            />
-            <Button
-              variant='primary'
-              title='Next'
-              disabled={isSubmitBtnDisabled()}
-              type='submit'
-            />
-          </Box>
-        </Box>
-      </Form>
+        </Form>
+      </Box>
     </>
   )
 }

--- a/components/Msig/Withdraw/index.jsx
+++ b/components/Msig/Withdraw/index.jsx
@@ -183,199 +183,201 @@ const Withdrawing = ({ address, balance, close }) => {
 
   return (
     <>
-      <ButtonClose
-        role='button'
-        type='button'
-        position='fixed'
-        top='3'
-        right='3'
-        onClick={() => {
-          setAttemptingTx(false)
-          setUncaughtError('')
-          resetLedgerState()
-          close()
-        }}
-      />
-      <Form onSubmit={onSubmit}>
-        <Box
-          maxWidth={14}
-          width={13}
-          minWidth={12}
-          display='flex'
-          flex='1'
-          flexDirection='column'
-          justifyContent='space-between'
-        >
-          <Box>
-            {hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
-              <ErrorCard
-                error={reportLedgerConfigError({
-                  ...ledger,
-                  otherError: uncaughtError
-                })}
-                reset={() => {
+      <Box display='flex' flexDirection='column' width='100%'>
+        <ButtonClose
+          role='button'
+          type='button'
+          justifySelf='flex-end'
+          marginLeft='auto'
+          onClick={() => {
+            setAttemptingTx(false)
+            setUncaughtError('')
+            resetLedgerState()
+            close()
+          }}
+        />
+        <Form onSubmit={onSubmit}>
+          <Box
+            maxWidth={13}
+            width='100%'
+            minWidth={11}
+            display='flex'
+            flex='1'
+            flexDirection='column'
+            justifyContent='flex-start'
+          >
+            <Box>
+              {hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
+                <ErrorCard
+                  error={reportLedgerConfigError({
+                    ...ledger,
+                    otherError: uncaughtError
+                  })}
+                  reset={() => {
+                    setAttemptingTx(false)
+                    setUncaughtError('')
+                    resetLedgerState()
+                    setStep(2)
+                  }}
+                />
+              )}
+              {attemptingTx && (
+                <ConfirmationCard
+                  loading={fetchingTxDetails || mPoolPushing}
+                  walletType={LEDGER}
+                  currentStep={5}
+                  totalSteps={5}
+                  msig
+                />
+              )}
+              {!attemptingTx &&
+                !hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
+                  <>
+                    <Card
+                      display='flex'
+                      flexDirection='column'
+                      justifyContent='space-between'
+                      border='none'
+                      width='auto'
+                      my={2}
+                      backgroundColor='blue.muted700'
+                    >
+                      <StepHeader
+                        title='Withdrawing Filecoin'
+                        currentStep={step}
+                        totalSteps={5}
+                        glyphAcronym='Wd'
+                      />
+                      <Box mt={3} mb={4}>
+                        <WithdrawHeaderText my={0} step={step} />
+                      </Box>
+                    </Card>
+                  </>
+                )}
+              <Box boxShadow={2} borderRadius={4}>
+                <CardHeader address={address} balance={balance} />
+                <Box width='100%' p={3} border={0} bg='background.screen'>
+                  <Input.Address
+                    label='Recipient'
+                    value={toAddress}
+                    onChange={e => setToAddress(e.target.value)}
+                    error={toAddressError}
+                    disabled={step >= 2}
+                    onFocus={() => {
+                      if (toAddressError) setToAddressError('')
+                    }}
+                  />
+                </Box>
+                {step > 1 && (
+                  <Box width='100%' p={3} border={0} bg='background.screen'>
+                    <Input.Funds
+                      name='amount'
+                      label='Amount'
+                      amount={value.toAttoFil()}
+                      onAmountChange={setValue}
+                      balance={balance}
+                      error={valueError}
+                      setError={setValueError}
+                      disabled={step === 3}
+                    />
+                  </Box>
+                )}
+                {step > 2 && (
+                  <>
+                    <Box
+                      width='100%'
+                      px={3}
+                      pb={step === 3 && 3}
+                      border={0}
+                      bg='background.screen'
+                    >
+                      <CustomizeFee
+                        message={constructMsg().message.toLotusType()}
+                        gasInfo={gasInfo}
+                        setGasInfo={setGasInfo}
+                        setFrozen={setFrozen}
+                        setError={setGasError}
+                        error={gasError}
+                        feeMustBeLessThanThisAmount={wallet.balance}
+                      />
+                    </Box>
+                    {step > 3 && (
+                      <Box
+                        display='flex'
+                        flexDirection='row'
+                        alignItems='flex-start'
+                        justifyContent='space-between'
+                        pt={6}
+                        pb={3}
+                        px={3}
+                        bg='background.screen'
+                        borderBottomLeftRadius={3}
+                        borderBottomRightRadius={3}
+                      >
+                        <Title fontSize={4} alignSelf='flex-start'>
+                          Total
+                        </Title>
+                        <Box
+                          display='flex'
+                          flexDirection='column'
+                          textAlign='right'
+                          pl={4}
+                        >
+                          <Num
+                            size='l'
+                            css={`
+                              word-wrap: break-word;
+                            `}
+                            color='core.primary'
+                          >
+                            {value.toFil()} FIL
+                          </Num>
+                        </Box>
+                      </Box>
+                    )}
+                  </>
+                )}
+              </Box>
+            </Box>
+
+            <Box
+              display='flex'
+              flex='1'
+              flexDirection='row'
+              justifyContent='space-between'
+              alignItems='flex-end'
+              margin='auto'
+              maxWidth={13}
+              width='100%'
+              minWidth={11}
+              maxHeight={12}
+              my={3}
+            >
+              <Button
+                title='Back'
+                variant='secondary'
+                onClick={() => {
                   setAttemptingTx(false)
                   setUncaughtError('')
                   resetLedgerState()
-                  setStep(2)
+                  if (step === 1) {
+                    close()
+                  } else {
+                    setStep(step - 1)
+                  }
                 }}
+                disabled={attemptingTx}
               />
-            )}
-            {attemptingTx && (
-              <ConfirmationCard
-                loading={fetchingTxDetails || mPoolPushing}
-                walletType={LEDGER}
-                currentStep={5}
-                totalSteps={5}
-                msig
+              <Button
+                variant='primary'
+                title='Next'
+                disabled={isSubmitBtnDisabled()}
+                type='submit'
               />
-            )}
-            {!attemptingTx &&
-              !hasLedgerError({ ...ledger, otherError: uncaughtError }) && (
-                <>
-                  <Card
-                    display='flex'
-                    flexDirection='column'
-                    justifyContent='space-between'
-                    border='none'
-                    width='auto'
-                    my={2}
-                    backgroundColor='blue.muted700'
-                  >
-                    <StepHeader
-                      title='Withdrawing Filecoin'
-                      currentStep={step}
-                      totalSteps={5}
-                      glyphAcronym='Wd'
-                    />
-                    <Box mt={3} mb={4}>
-                      <WithdrawHeaderText my={0} step={step} />
-                    </Box>
-                  </Card>
-                </>
-              )}
-            <Box boxShadow={2} borderRadius={4}>
-              <CardHeader address={address} balance={balance} />
-              <Box width='100%' p={3} border={0} bg='background.screen'>
-                <Input.Address
-                  label='Recipient'
-                  value={toAddress}
-                  onChange={e => setToAddress(e.target.value)}
-                  error={toAddressError}
-                  disabled={step >= 2}
-                  onFocus={() => {
-                    if (toAddressError) setToAddressError('')
-                  }}
-                />
-              </Box>
-              {step > 1 && (
-                <Box width='100%' p={3} border={0} bg='background.screen'>
-                  <Input.Funds
-                    name='amount'
-                    label='Amount'
-                    amount={value.toAttoFil()}
-                    onAmountChange={setValue}
-                    balance={balance}
-                    error={valueError}
-                    setError={setValueError}
-                    disabled={step === 3}
-                  />
-                </Box>
-              )}
-              {step > 2 && (
-                <>
-                  <Box
-                    width='100%'
-                    px={3}
-                    pb={step === 3 && 3}
-                    border={0}
-                    bg='background.screen'
-                  >
-                    <CustomizeFee
-                      message={constructMsg().message.toLotusType()}
-                      gasInfo={gasInfo}
-                      setGasInfo={setGasInfo}
-                      setFrozen={setFrozen}
-                      setError={setGasError}
-                      error={gasError}
-                      feeMustBeLessThanThisAmount={wallet.balance}
-                    />
-                  </Box>
-                  {step > 3 && (
-                    <Box
-                      display='flex'
-                      flexDirection='row'
-                      alignItems='flex-start'
-                      justifyContent='space-between'
-                      pt={6}
-                      pb={3}
-                      px={3}
-                      bg='background.screen'
-                      borderBottomLeftRadius={3}
-                      borderBottomRightRadius={3}
-                    >
-                      <Title fontSize={4} alignSelf='flex-start'>
-                        Total
-                      </Title>
-                      <Box
-                        display='flex'
-                        flexDirection='column'
-                        textAlign='right'
-                        pl={4}
-                      >
-                        <Num
-                          size='l'
-                          css={`
-                            word-wrap: break-word;
-                          `}
-                          color='core.primary'
-                        >
-                          {value.toFil()} FIL
-                        </Num>
-                      </Box>
-                    </Box>
-                  )}
-                </>
-              )}
             </Box>
           </Box>
-
-          <Box
-            display='flex'
-            flex='1'
-            flexDirection='row'
-            justifyContent='space-between'
-            alignItems='flex-end'
-            margin='auto'
-            maxWidth={14}
-            width={13}
-            minWidth={12}
-            mt={4}
-          >
-            <Button
-              title='Back'
-              variant='secondary'
-              onClick={() => {
-                setAttemptingTx(false)
-                setUncaughtError('')
-                resetLedgerState()
-                if (step === 1) {
-                  close()
-                } else {
-                  setStep(step - 1)
-                }
-              }}
-              disabled={attemptingTx}
-            />
-            <Button
-              variant='primary'
-              title='Next'
-              disabled={isSubmitBtnDisabled()}
-              type='submit'
-            />
-          </Box>
-        </Box>
-      </Form>
+        </Form>
+      </Box>
     </>
   )
 }

--- a/components/Onboarding/Choose/__snapshots__/index.test.js.snap
+++ b/components/Onboarding/Choose/__snapshots__/index.test.js.snap
@@ -2429,11 +2429,6 @@ exports[`Choosing a wallet it renders correctly 1`] = `
 `;
 
 exports[`Choosing a wallet it renders warning text for create wallet option 1`] = `
-.c3 {
-  min-width: 0;
-  box-sizing: border-box;
-}
-
 .c0 {
   min-width: 0;
   box-sizing: border-box;
@@ -2443,7 +2438,6 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   display: -ms-flexbox;
   display: flex;
   width: 100%;
-  height: 90vh;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2451,10 +2445,10 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
 .c1 {
@@ -2482,11 +2476,8 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   border: 1px solid;
   border-radius: 4px;
   border-width: 1px;
-  border-color: #FF9E80;
-  padding: 16px;
+  padding: 0;
   margin-left: 8px;
-  background-color: #FF9E80;
-  color: #661800;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2498,6 +2489,25 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c3 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 16px;
+  background-color: #FF9E80;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -2510,6 +2520,7 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   border-width: 0.1875rem;
   border-radius: 8px;
   border-style: solid;
+  background-color: #FF9E80;
   color: #661800;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2527,11 +2538,13 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   justify-content: center;
 }
 
-.c8 {
+.c7 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 24px;
+  padding-bottom: 24px;
 }
 
 .c10 {
@@ -2596,16 +2609,15 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
 }
 
 .c6 {
+  color: #661800;
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
   margin: 0;
-  margin-top: 24px;
-  margin-bottom: 8px;
 }
 
-.c7 {
+.c8 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -2624,7 +2636,7 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   -webkit-transition: 0.18s ease-in-out;
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
-  color: #ffffff;
+  color: #5E26FF;
   font-size: 1.25rem;
 }
 
@@ -2687,7 +2699,6 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
 <div
   class="c0"
   display="flex"
-  height="90vh"
   width="100%"
 >
   <div
@@ -2696,13 +2707,13 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
   >
     <div
       class="c2"
-      color="status.warning.foreground"
       display="flex"
       overflow="hidden"
       width="100%"
     >
       <div
         class="c3"
+        display="flex"
       >
         <div
           class="c4"
@@ -2718,27 +2729,28 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
         </div>
         <h2
           class="c6"
+          color="status.warning.foreground"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
         >
           Warning
         </h2>
+      </div>
+      <div
+        class="c7"
+      >
         <p
-          class="c7"
+          class="c8"
           font-family="RT-Alias-Grotesk"
           font-size="2"
           font-weight="400"
         >
           We do not recommend you use this account to hold or transact significant sums of Filecoin. This account is for testing purposes only. For significant sums, Glif should only be used with a Ledger hardware wallet.
         </p>
-      </div>
-      <div
-        class="c8"
-      >
         <a
           class="c9"
-          color="core.white"
+          color="core.primary"
           font-size="3"
           href="https://coinsutra.com/security-risks-bitcoin-wallets/"
           rel="noopener"
@@ -2774,11 +2786,6 @@ exports[`Choosing a wallet it renders warning text for create wallet option 1`] 
 `;
 
 exports[`Choosing a wallet it renders warning text for import private key option 1`] = `
-.c3 {
-  min-width: 0;
-  box-sizing: border-box;
-}
-
 .c0 {
   min-width: 0;
   box-sizing: border-box;
@@ -2788,7 +2795,6 @@ exports[`Choosing a wallet it renders warning text for import private key option
   display: -ms-flexbox;
   display: flex;
   width: 100%;
-  height: 90vh;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -2796,10 +2802,10 @@ exports[`Choosing a wallet it renders warning text for import private key option
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
 .c1 {
@@ -2827,11 +2833,8 @@ exports[`Choosing a wallet it renders warning text for import private key option
   border: 1px solid;
   border-radius: 4px;
   border-width: 1px;
-  border-color: #FF9E80;
-  padding: 16px;
+  padding: 0;
   margin-left: 8px;
-  background-color: #FF9E80;
-  color: #661800;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2843,6 +2846,25 @@ exports[`Choosing a wallet it renders warning text for import private key option
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c3 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 16px;
+  background-color: #FF9E80;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -2855,6 +2877,7 @@ exports[`Choosing a wallet it renders warning text for import private key option
   border-width: 0.1875rem;
   border-radius: 8px;
   border-style: solid;
+  background-color: #FF9E80;
   color: #661800;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2872,11 +2895,13 @@ exports[`Choosing a wallet it renders warning text for import private key option
   justify-content: center;
 }
 
-.c8 {
+.c7 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 24px;
+  padding-bottom: 24px;
 }
 
 .c10 {
@@ -2941,16 +2966,15 @@ exports[`Choosing a wallet it renders warning text for import private key option
 }
 
 .c6 {
+  color: #661800;
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
   margin: 0;
-  margin-top: 24px;
-  margin-bottom: 8px;
 }
 
-.c7 {
+.c8 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -2969,7 +2993,7 @@ exports[`Choosing a wallet it renders warning text for import private key option
   -webkit-transition: 0.18s ease-in-out;
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
-  color: #ffffff;
+  color: #5E26FF;
   font-size: 1.25rem;
 }
 
@@ -3032,7 +3056,6 @@ exports[`Choosing a wallet it renders warning text for import private key option
 <div
   class="c0"
   display="flex"
-  height="90vh"
   width="100%"
 >
   <div
@@ -3041,13 +3064,13 @@ exports[`Choosing a wallet it renders warning text for import private key option
   >
     <div
       class="c2"
-      color="status.warning.foreground"
       display="flex"
       overflow="hidden"
       width="100%"
     >
       <div
         class="c3"
+        display="flex"
       >
         <div
           class="c4"
@@ -3063,27 +3086,28 @@ exports[`Choosing a wallet it renders warning text for import private key option
         </div>
         <h2
           class="c6"
+          color="status.warning.foreground"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
         >
           Warning
         </h2>
+      </div>
+      <div
+        class="c7"
+      >
         <p
-          class="c7"
+          class="c8"
           font-family="RT-Alias-Grotesk"
           font-size="2"
           font-weight="400"
         >
           We do not recommend you use this account to hold or transact significant sums of Filecoin. This account is for testing purposes only. For significant sums, Glif should only be used with a Ledger hardware wallet.
         </p>
-      </div>
-      <div
-        class="c8"
-      >
         <a
           class="c9"
-          color="core.white"
+          color="core.primary"
           font-size="3"
           href="https://coinsutra.com/security-risks-bitcoin-wallets/"
           rel="noopener"
@@ -3119,11 +3143,6 @@ exports[`Choosing a wallet it renders warning text for import private key option
 `;
 
 exports[`Choosing a wallet it renders warning text for import seed option 1`] = `
-.c3 {
-  min-width: 0;
-  box-sizing: border-box;
-}
-
 .c0 {
   min-width: 0;
   box-sizing: border-box;
@@ -3133,7 +3152,6 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   display: -ms-flexbox;
   display: flex;
   width: 100%;
-  height: 90vh;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -3141,10 +3159,10 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
 .c1 {
@@ -3172,11 +3190,8 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   border: 1px solid;
   border-radius: 4px;
   border-width: 1px;
-  border-color: #FF9E80;
-  padding: 16px;
+  padding: 0;
   margin-left: 8px;
-  background-color: #FF9E80;
-  color: #661800;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3188,6 +3203,25 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c3 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 16px;
+  background-color: #FF9E80;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -3200,6 +3234,7 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   border-width: 0.1875rem;
   border-radius: 8px;
   border-style: solid;
+  background-color: #FF9E80;
   color: #661800;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3217,11 +3252,13 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   justify-content: center;
 }
 
-.c8 {
+.c7 {
   min-width: 0;
   box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 24px;
+  padding-bottom: 24px;
 }
 
 .c10 {
@@ -3286,16 +3323,15 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
 }
 
 .c6 {
+  color: #661800;
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
   margin: 0;
-  margin-top: 24px;
-  margin-bottom: 8px;
 }
 
-.c7 {
+.c8 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -3314,7 +3350,7 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   -webkit-transition: 0.18s ease-in-out;
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
-  color: #ffffff;
+  color: #5E26FF;
   font-size: 1.25rem;
 }
 
@@ -3377,7 +3413,6 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
 <div
   class="c0"
   display="flex"
-  height="90vh"
   width="100%"
 >
   <div
@@ -3386,13 +3421,13 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
   >
     <div
       class="c2"
-      color="status.warning.foreground"
       display="flex"
       overflow="hidden"
       width="100%"
     >
       <div
         class="c3"
+        display="flex"
       >
         <div
           class="c4"
@@ -3408,27 +3443,28 @@ exports[`Choosing a wallet it renders warning text for import seed option 1`] = 
         </div>
         <h2
           class="c6"
+          color="status.warning.foreground"
           font-family="RT-Alias-Grotesk"
           font-size="4"
           font-weight="400"
         >
           Warning
         </h2>
+      </div>
+      <div
+        class="c7"
+      >
         <p
-          class="c7"
+          class="c8"
           font-family="RT-Alias-Grotesk"
           font-size="2"
           font-weight="400"
         >
           We do not recommend you use this account to hold or transact significant sums of Filecoin. This account is for testing purposes only. For significant sums, Glif should only be used with a Ledger hardware wallet.
         </p>
-      </div>
-      <div
-        class="c8"
-      >
         <a
           class="c9"
-          color="core.white"
+          color="core.primary"
           font-size="3"
           href="https://coinsutra.com/security-risks-bitcoin-wallets/"
           rel="noopener"

--- a/components/Shared/Input/Funds.jsx
+++ b/components/Shared/Input/Funds.jsx
@@ -155,6 +155,7 @@ const Funds = forwardRef(
               valid={valid && !!formatFilValue(filAmount)}
               {...props}
               my={0}
+              px={3}
             />
             <DenomTag
               top='0px'

--- a/components/Shared/Input/Number.jsx
+++ b/components/Shared/Input/Number.jsx
@@ -61,7 +61,7 @@ export const NumberInput = forwardRef(
               display='inline-block'
               px={2}
               mr={2}
-              minWidth={[9, 9, 10]}
+              minWidth={10}
               textAlign='left'
             >
               <Label>{label}</Label>

--- a/components/Shared/Input/__snapshots__/Funds.test.js.snap
+++ b/components/Shared/Input/__snapshots__/Funds.test.js.snap
@@ -125,6 +125,8 @@ exports[`Funds input it renders !disabled and invalid state correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -335,6 +337,8 @@ exports[`Funds input it renders correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -545,6 +549,8 @@ exports[`Funds input it renders disabled and invalid state correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -757,6 +763,8 @@ exports[`Funds input it renders disabled and valid state correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -969,6 +977,8 @@ exports[`Funds input it renders disabled state correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -1184,6 +1194,8 @@ exports[`Funds input it renders error states properly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -1394,6 +1406,8 @@ exports[`Funds input it renders invalid state correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;

--- a/components/Shared/Warning/index.jsx
+++ b/components/Shared/Warning/index.jsx
@@ -51,7 +51,7 @@ const WarningCard = ({
         <OnboardCard
           display='flex'
           flexDirection='column'
-          justifyContent='space-between'
+          justifyContent='flex-start'
           ml={2}
           minHeight={11}
           p={0}

--- a/components/Shared/Warning/index.jsx
+++ b/components/Shared/Warning/index.jsx
@@ -15,7 +15,7 @@ const DescriptionText = ({ description }) => {
   return (
     <>
       {description.map(d => (
-        <Text>{d}</Text>
+        <Text mt={0}>{d}</Text>
       ))}
     </>
   )
@@ -38,9 +38,8 @@ const WarningCard = ({
       display='flex'
       flexDirection='column'
       width='100%'
-      height='90vh'
       alignItems='center'
-      justifyContent='center'
+      justifyContent='flex-start'
       p={4}
     >
       <Box
@@ -53,27 +52,32 @@ const WarningCard = ({
           display='flex'
           flexDirection='column'
           justifyContent='space-between'
-          borderColor='status.warning.background'
-          bg='status.warning.background'
-          color='status.warning.foreground'
           ml={2}
           minHeight={11}
+          p={0}
         >
-          <Box>
-            <Glyph color='status.warning.foreground' acronym='Wn' />
-            <Title mt={4} mb={2}>
-              {title}
-            </Title>
-            <DescriptionText description={description} />
+          <Box
+            display='flex'
+            alignItems='center'
+            justifyContent='space-between'
+            bg='status.warning.background'
+            p={3}
+          >
+            <Glyph
+              color='status.warning.foreground'
+              bg='status.warning.background'
+              acronym='Wn'
+            />
+            <Title color='status.warning.foreground'>{title}</Title>
           </Box>
+          <Box px={3} py={4}>
+            <DescriptionText color='core.nearblack' description={description} />
 
-          <Box my={3}>
             <StyledATag
               rel='noopener'
               target='_blank'
               href={linkhref}
               fontSize={3}
-              color='core.white'
             >
               {linkDisplay}
             </StyledATag>

--- a/components/Wallet/Message/Detail/__snapshots__/index.test.js.snap
+++ b/components/Wallet/Message/Detail/__snapshots__/index.test.js.snap
@@ -567,6 +567,8 @@ exports[`MessageHistory View it renders a final, received, SEND transaction corr
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -1601,6 +1603,8 @@ exports[`MessageHistory View it renders a final, sent, SEND transaction correctl
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -2637,6 +2641,8 @@ exports[`MessageHistory View it renders a pending, send transaction correctly 1`
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;

--- a/components/Wallet/Message/__snapshots__/index.test.js.snap
+++ b/components/Wallet/Message/__snapshots__/index.test.js.snap
@@ -2559,6 +2559,8 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;

--- a/components/Wallet/Send.js/CustomizeFee.jsx
+++ b/components/Wallet/Send.js/CustomizeFee.jsx
@@ -29,7 +29,7 @@ const Helper = ({
 
   if (dirty) {
     return (
-      <>
+      <Box display='flex' justifyContent='flex-end' width='100%'>
         <Button
           variant='secondary'
           title='Save'
@@ -45,13 +45,13 @@ const Helper = ({
           onClick={reset}
           disabled={saving}
         />
-      </>
+      </Box>
     )
   }
 
   return (
-    <Text color='core.darkgray'>
-      *You will not pay more than {estimatedTransactionFee.toFil()} FIL for this
+    <Text width='100%' color='core.darkgray'>
+      You will not pay more than {estimatedTransactionFee.toFil()} FIL for this
       transaction.
     </Text>
   )
@@ -200,7 +200,6 @@ const CustomizeFee = ({
             display='flex'
             justifyContent='flex-start'
             textAlign='left'
-            maxWidth='280px'
             width='100%'
           >
             <Helper

--- a/components/Wallet/Send.js/CustomizeFee.jsx
+++ b/components/Wallet/Send.js/CustomizeFee.jsx
@@ -29,7 +29,7 @@ const Helper = ({
 
   if (dirty) {
     return (
-      <Box display='flex' justifyContent='flex-end' width='100%'>
+      <>
         <Button
           variant='secondary'
           title='Save'
@@ -45,7 +45,7 @@ const Helper = ({
           onClick={reset}
           disabled={saving}
         />
-      </Box>
+      </>
     )
   }
 
@@ -198,7 +198,7 @@ const CustomizeFee = ({
           />
           <Box
             display='flex'
-            justifyContent='flex-start'
+            justifyContent='flex-end'
             textAlign='left'
             width='100%'
           >

--- a/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
+++ b/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
@@ -519,7 +519,6 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {
@@ -1389,7 +1388,6 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {
@@ -2608,7 +2606,6 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {
@@ -3758,7 +3755,6 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {
@@ -5029,7 +5025,6 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {
@@ -6420,7 +6415,6 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {
@@ -7829,7 +7823,6 @@ exports[`Send Flow snapshots it renders step 5 correctly 1`] = `
   display: inline-block;
   margin-left: auto;
   justify-self: flex-end;
-  position: relative;
 }
 
 .c1:hover {

--- a/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
+++ b/components/Wallet/Send.js/__snapshots__/index.test.jsx.snap
@@ -1,12 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Send Flow snapshots it renders correctly 1`] = `
-.c3 {
+.c0 {
   min-width: 0;
   box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -17,18 +30,18 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
-.c4 {
+.c5 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   min-width: 0;
   box-sizing: border-box;
   border: none;
@@ -53,7 +66,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -69,7 +82,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c10 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -92,7 +105,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c13 {
   min-width: 0;
   box-sizing: border-box;
   margin-left: 24px;
@@ -104,7 +117,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   display: flex;
 }
 
-.c14 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -117,7 +130,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -129,7 +142,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   height: 8px;
 }
 
-.c16 {
+.c17 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -141,21 +154,21 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   height: 8px;
 }
 
-.c17 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 48px;
   margin-bottom: 24px;
 }
 
-.c19 {
+.c20 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 16px;
   box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
 }
 
-.c20 {
+.c21 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -167,7 +180,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   width: 100%;
 }
 
-.c21 {
+.c22 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -187,7 +200,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c22 {
+.c23 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -211,7 +224,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -227,7 +240,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: flex-start;
 }
 
-.c25 {
+.c26 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -236,7 +249,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   width: 100%;
 }
 
-.c27 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   margin-right: 16px;
@@ -255,7 +268,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -272,7 +285,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: center;
 }
 
-.c31 {
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   margin: auto;
@@ -282,9 +295,10 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -302,13 +316,13 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: flex-end;
 }
 
-.c10 {
+.c11 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c32 {
+.c33 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -327,11 +341,11 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-radius: 4px;
 }
 
-.c32:hover {
+.c33:hover {
   opacity: 0.8;
 }
 
-.c33 {
+.c34 {
   cursor: not-allowed;
   border: 1px solid #C4C4C4;
   background-color: #C4C4C4;
@@ -349,16 +363,16 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-radius: 4px;
 }
 
-.c33:hover {
+.c34:hover {
   opacity: 1;
 }
 
-.c1 {
+.c2 {
   width: 24;
   height: 24;
 }
 
-.c11 {
+.c12 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -366,7 +380,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c14 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -377,7 +391,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c19 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -386,7 +400,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -394,7 +408,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c28 {
+.c29 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -403,7 +417,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -428,24 +442,24 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c31:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c30:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   width: 100%;
   border-radius: 1px;
 }
 
-.c2 {
+.c3 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -463,7 +477,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -483,7 +497,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c9 {
   margin-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -495,7 +509,7 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c0 {
+.c1 {
   outline: 0;
   border: 0;
   background: transparent;
@@ -503,341 +517,360 @@ exports[`Send Flow snapshots it renders correctly 1`] = `
   transition: 0.24s ease-in-out;
   cursor: pointer;
   display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
 }
 
-.c0:hover {
+.c1:hover {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
 <div>
-  <button
+  <div
     class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
+    display="flex"
+    width="100%"
   >
-    <svg
+    <button
       class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      display="inline-block"
+      role="button"
+      type="button"
     >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
       class="c3"
-      display="flex"
-      width="13"
     >
       <div
         class="c4"
+        display="flex"
+        width="100%"
       >
         <div
           class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
         >
-          <ul
+          <div
             class="c6"
             display="flex"
-            width="100%"
+            overflow="hidden"
+            width="auto"
           >
-            <div
+            <ul
               class="c7"
               display="flex"
+              width="100%"
             >
-              <li
+              <div
                 class="c8"
                 display="flex"
               >
-                <div
+                <li
                   class="c9"
-                  color="#000"
                   display="flex"
-                  size="6"
                 >
-                  <h3
+                  <div
                     class="c10"
+                    color="#000"
+                    display="flex"
+                    size="6"
                   >
-                    Sf
-                  </h3>
-                </div>
-              </li>
+                    <h3
+                      class="c11"
+                    >
+                      Sf
+                    </h3>
+                  </div>
+                </li>
+                <li
+                  class=""
+                >
+                  <h2
+                    class="c12"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="4"
+                    font-weight="400"
+                  >
+                    Sending Filecoin
+                  </h2>
+                </li>
+              </div>
               <li
                 class=""
               >
-                <h2
-                  class="c11"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="4"
-                  font-weight="400"
-                >
-                  Sending Filecoin
-                </h2>
-              </li>
-            </div>
-            <li
-              class=""
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
-                <p
+                <div
                   class="c13"
-                  color="core.nearblack"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Step 
-                  1
-                </p>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-              </div>
-            </li>
-          </ul>
-          <div
-            class="c17"
-          >
-            <p
-              class="c18"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              First, please confirm the account you're sending from, and the recipient you want to send to.
-            </p>
-          </div>
-        </div>
-        <div
-          class="c19"
-        >
-          <div
-            class="c20"
-            color="core.white"
-            width="100%"
-          >
-            <div
-              class="c21"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c22"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c23"
                   display="flex"
                 >
                   <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    From
-                  </p>
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    t1z225 ... 6z6wgi
-                  </p>
-                </div>
-              </div>
-              <div
-                class="c23"
-                display="flex"
-              >
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c25"
-            width="100%"
-          >
-            <div
-              class="c26"
-            >
-              <div
-                class="c14"
-                display="flex"
-              >
-                <div
-                  class="c27"
-                  display="flex"
-                >
-                  <h4
-                    class="c28"
+                    class="c14"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    Recipient
-                  </h4>
+                    Step 
+                    1
+                  </p>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                 </div>
+              </li>
+            </ul>
+            <div
+              class="c18"
+            >
+              <p
+                class="c19"
+                font-family="RT-Alias-Grotesk"
+                font-size="2"
+                font-weight="400"
+              >
+                First, please confirm the account you're sending from, and the recipient you want to send to.
+              </p>
+            </div>
+          </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21"
+              color="core.white"
+              width="100%"
+            >
+              <div
+                class="c22"
+                display="flex"
+              >
                 <div
-                  class="c29"
+                  class="c8"
                   display="flex"
                 >
-                  <input
-                    class="c30"
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value=""
-                    width="100%"
-                  />
-                  
+                  <div
+                    class="c23"
+                    color="white"
+                    display="flex"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Ms
+                    </h3>
+                  </div>
+                  <div
+                    class="c24"
+                    display="flex"
+                  >
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      From
+                    </p>
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c24"
+                  display="flex"
+                >
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Balance
+                  </p>
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    1
+                     FIL
+                  </p>
                 </div>
               </div>
             </div>
-            
+            <div
+              class="c26"
+              width="100%"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c15"
+                  display="flex"
+                >
+                  <div
+                    class="c28"
+                    display="flex"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c30"
+                    display="flex"
+                  >
+                    <input
+                      class="c31"
+                      display="inline-block"
+                      height="6"
+                      placeholder="f1..."
+                      value=""
+                      width="100%"
+                    />
+                    
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              class="c5"
+            />
           </div>
-          <div
-            class="c4"
-          />
+        </div>
+        <div
+          class="c32"
+          display="flex"
+          width="100%"
+        >
+          <button
+            class="c33"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c34"
+            disabled=""
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Next
+          </button>
         </div>
       </div>
-      <div
-        class="c31"
-        display="flex"
-        width="13"
-      >
-        <button
-          class="c32"
-          font-size="3"
-          height="6"
-          type="button"
-        >
-          Back
-        </button>
-        <button
-          class="c33"
-          disabled=""
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Next
-        </button>
-      </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>
 `;
 
 exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
-.c3 {
+.c0 {
   min-width: 0;
   box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -848,18 +881,18 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
-.c4 {
+.c5 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   min-width: 0;
   box-sizing: border-box;
   border: none;
@@ -884,7 +917,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -900,7 +933,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c10 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -923,7 +956,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c13 {
   min-width: 0;
   box-sizing: border-box;
   margin-left: 24px;
@@ -935,7 +968,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   display: flex;
 }
 
-.c14 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -948,7 +981,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -960,7 +993,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   height: 8px;
 }
 
-.c16 {
+.c17 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -972,21 +1005,21 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   height: 8px;
 }
 
-.c17 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 48px;
   margin-bottom: 24px;
 }
 
-.c19 {
+.c20 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 16px;
   box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
 }
 
-.c20 {
+.c21 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -998,7 +1031,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   width: 100%;
 }
 
-.c21 {
+.c22 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1018,7 +1051,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c22 {
+.c23 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -1042,7 +1075,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1058,7 +1091,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: flex-start;
 }
 
-.c25 {
+.c26 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -1067,7 +1100,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   width: 100%;
 }
 
-.c27 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   margin-right: 16px;
@@ -1086,7 +1119,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -1103,7 +1136,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
   margin: auto;
@@ -1113,9 +1146,10 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1133,7 +1167,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: flex-end;
 }
 
-.c31 {
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   padding-top: 8px;
@@ -1141,41 +1175,18 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   text-align: right;
 }
 
-.c10 {
+.c11 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c34 {
+.c35 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
   border-color: #262626;
   color: #262626;
-  font-size: 1.125rem;
-  -webkit-transition: 0.18s ease-in-out;
-  transition: 0.18s ease-in-out;
-  border-radius: 4px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 16px;
-  padding-right: 16px;
-  height: 48px;
-  border-width: 1px;
-  border-radius: 4px;
-}
-
-.c34:hover {
-  opacity: 0.8;
-}
-
-.c35 {
-  cursor: pointer;
-  border: 1px solid #1AD08F;
-  background-color: #1AD08F;
-  border-color: #1AD08F;
-  color: #08442F;
   font-size: 1.125rem;
   -webkit-transition: 0.18s ease-in-out;
   transition: 0.18s ease-in-out;
@@ -1193,12 +1204,35 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   opacity: 0.8;
 }
 
-.c1 {
+.c36 {
+  cursor: pointer;
+  border: 1px solid #1AD08F;
+  background-color: #1AD08F;
+  border-color: #1AD08F;
+  color: #08442F;
+  font-size: 1.125rem;
+  -webkit-transition: 0.18s ease-in-out;
+  transition: 0.18s ease-in-out;
+  border-radius: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: 48px;
+  border-width: 1px;
+  border-radius: 4px;
+}
+
+.c36:hover {
+  opacity: 0.8;
+}
+
+.c2 {
   width: 24;
   height: 24;
 }
 
-.c11 {
+.c12 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -1206,7 +1240,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c14 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -1217,7 +1251,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c19 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -1226,7 +1260,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -1234,7 +1268,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c28 {
+.c29 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -1243,7 +1277,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c32 {
+.c33 {
   color: #FC6D6F;
   font-size: 1.125rem;
   font-weight: 400;
@@ -1253,7 +1287,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1278,24 +1312,24 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c31:hover {
   background: #FC6D6F;
   cursor: text;
 }
 
-.c30:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #FC6D6F;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   width: 100%;
   border-radius: 1px;
 }
 
-.c2 {
+.c3 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1313,7 +1347,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -1333,7 +1367,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c9 {
   margin-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1345,7 +1379,7 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c0 {
+.c1 {
   outline: 0;
   border: 0;
   background: transparent;
@@ -1353,352 +1387,371 @@ exports[`Send Flow snapshots it renders invalid address errors correctly 1`] = `
   transition: 0.24s ease-in-out;
   cursor: pointer;
   display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
 }
 
-.c0:hover {
+.c1:hover {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
 <div>
-  <button
+  <div
     class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
+    display="flex"
+    width="100%"
   >
-    <svg
+    <button
       class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      display="inline-block"
+      role="button"
+      type="button"
     >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
       class="c3"
-      display="flex"
-      width="13"
     >
       <div
         class="c4"
+        display="flex"
+        width="100%"
       >
         <div
           class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
         >
-          <ul
+          <div
             class="c6"
             display="flex"
-            width="100%"
+            overflow="hidden"
+            width="auto"
           >
-            <div
+            <ul
               class="c7"
               display="flex"
+              width="100%"
             >
-              <li
+              <div
                 class="c8"
                 display="flex"
               >
-                <div
+                <li
                   class="c9"
-                  color="#000"
                   display="flex"
-                  size="6"
                 >
-                  <h3
+                  <div
                     class="c10"
+                    color="#000"
+                    display="flex"
+                    size="6"
                   >
-                    Sf
-                  </h3>
-                </div>
-              </li>
+                    <h3
+                      class="c11"
+                    >
+                      Sf
+                    </h3>
+                  </div>
+                </li>
+                <li
+                  class=""
+                >
+                  <h2
+                    class="c12"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="4"
+                    font-weight="400"
+                  >
+                    Sending Filecoin
+                  </h2>
+                </li>
+              </div>
               <li
                 class=""
               >
-                <h2
-                  class="c11"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="4"
-                  font-weight="400"
-                >
-                  Sending Filecoin
-                </h2>
-              </li>
-            </div>
-            <li
-              class=""
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
-                <p
+                <div
                   class="c13"
-                  color="core.nearblack"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Step 
-                  1
-                </p>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-              </div>
-            </li>
-          </ul>
-          <div
-            class="c17"
-          >
-            <p
-              class="c18"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              First, please confirm the account you're sending from, and the recipient you want to send to.
-            </p>
-          </div>
-        </div>
-        <div
-          class="c19"
-        >
-          <div
-            class="c20"
-            color="core.white"
-            width="100%"
-          >
-            <div
-              class="c21"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c22"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c23"
                   display="flex"
                 >
                   <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    From
-                  </p>
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    t1z225 ... 6z6wgi
-                  </p>
-                </div>
-              </div>
-              <div
-                class="c23"
-                display="flex"
-              >
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c25"
-            width="100%"
-          >
-            <div
-              class="c26"
-            >
-              <div
-                class="c14"
-                display="flex"
-              >
-                <div
-                  class="c27"
-                  display="flex"
-                >
-                  <h4
-                    class="c28"
+                    class="c14"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    Recipient
-                  </h4>
+                    Step 
+                    1
+                  </p>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                 </div>
-                <div
-                  class="c29"
-                  display="flex"
-                >
-                  <input
-                    class="c30"
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value="t1z225tguggx4onbauimqvxz"
-                    width="100%"
-                  />
-                  
-                </div>
-              </div>
-            </div>
+              </li>
+            </ul>
             <div
-              class="c31"
+              class="c18"
             >
-              <h4
-                class="c32"
-                color="status.fail.background"
+              <p
+                class="c19"
                 font-family="RT-Alias-Grotesk"
                 font-size="2"
                 font-weight="400"
               >
-                Invalid to address
-              </h4>
+                First, please confirm the account you're sending from, and the recipient you want to send to.
+              </p>
             </div>
           </div>
           <div
-            class="c4"
-          />
+            class="c20"
+          >
+            <div
+              class="c21"
+              color="core.white"
+              width="100%"
+            >
+              <div
+                class="c22"
+                display="flex"
+              >
+                <div
+                  class="c8"
+                  display="flex"
+                >
+                  <div
+                    class="c23"
+                    color="white"
+                    display="flex"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Ms
+                    </h3>
+                  </div>
+                  <div
+                    class="c24"
+                    display="flex"
+                  >
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      From
+                    </p>
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c24"
+                  display="flex"
+                >
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Balance
+                  </p>
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    1
+                     FIL
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="c26"
+              width="100%"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c15"
+                  display="flex"
+                >
+                  <div
+                    class="c28"
+                    display="flex"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c30"
+                    display="flex"
+                  >
+                    <input
+                      class="c31"
+                      display="inline-block"
+                      height="6"
+                      placeholder="f1..."
+                      value="t1z225tguggx4onbauimqvxz"
+                      width="100%"
+                    />
+                    
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c32"
+              >
+                <h4
+                  class="c33"
+                  color="status.fail.background"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="2"
+                  font-weight="400"
+                >
+                  Invalid to address
+                </h4>
+              </div>
+            </div>
+            <div
+              class="c5"
+            />
+          </div>
+        </div>
+        <div
+          class="c34"
+          display="flex"
+          width="100%"
+        >
+          <button
+            class="c35"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c36"
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Next
+          </button>
         </div>
       </div>
-      <div
-        class="c33"
-        display="flex"
-        width="13"
-      >
-        <button
-          class="c34"
-          font-size="3"
-          height="6"
-          type="button"
-        >
-          Back
-        </button>
-        <button
-          class="c35"
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Next
-        </button>
-      </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>
 `;
 
 exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
-.c3 {
+.c0 {
   min-width: 0;
   box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1709,18 +1762,18 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
-.c4 {
+.c5 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   min-width: 0;
   box-sizing: border-box;
   border: none;
@@ -1745,7 +1798,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1761,7 +1814,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c10 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -1784,7 +1837,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c13 {
   min-width: 0;
   box-sizing: border-box;
   margin-left: 24px;
@@ -1796,7 +1849,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   display: flex;
 }
 
-.c14 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1809,7 +1862,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -1821,7 +1874,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   height: 8px;
 }
 
-.c16 {
+.c17 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -1833,21 +1886,21 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   height: 8px;
 }
 
-.c17 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 48px;
   margin-bottom: 24px;
 }
 
-.c19 {
+.c20 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 16px;
   box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
 }
 
-.c20 {
+.c21 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -1859,7 +1912,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   width: 100%;
 }
 
-.c21 {
+.c22 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1879,7 +1932,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c22 {
+.c23 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -1903,7 +1956,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1919,7 +1972,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: flex-start;
 }
 
-.c25 {
+.c26 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -1928,7 +1981,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   width: 100%;
 }
 
-.c27 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   margin-right: 16px;
@@ -1947,7 +2000,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -1964,7 +2017,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c50 {
   min-width: 0;
   box-sizing: border-box;
   margin: auto;
@@ -1974,9 +2027,10 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1994,7 +2048,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: flex-end;
 }
 
-.c38 {
+.c39 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -2005,7 +2059,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   width: 100%;
 }
 
-.c32 {
+.c33 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -2021,7 +2075,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 4px;
@@ -2050,14 +2104,14 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   text-align: center;
 }
 
-.c34 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
   display: inline-block;
   width: 100%;
 }
 
-.c35 {
+.c36 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -2072,7 +2126,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   width: 100%;
 }
 
-.c31 {
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -2082,7 +2136,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   width: 100%;
 }
 
-.c39 {
+.c40 {
   min-width: 0;
   box-sizing: border-box;
   background-color: #EFF3FD;
@@ -2103,7 +2157,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c40 {
+.c41 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -2124,7 +2178,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   flex-grow: 1;
 }
 
-.c41 {
+.c42 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -2138,18 +2192,18 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c42 {
+.c43 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 8px;
   padding-right: 8px;
   margin-right: 8px;
   display: inline-block;
-  min-width: 160px;
+  min-width: 240px;
   text-align: left;
 }
 
-.c44 {
+.c45 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -2167,29 +2221,28 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: flex-end;
 }
 
-.c47 {
+.c48 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 280px;
   width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
   text-align: left;
 }
 
-.c10 {
+.c11 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c50 {
+.c51 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -2208,11 +2261,11 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-radius: 4px;
 }
 
-.c50:hover {
+.c51:hover {
   opacity: 0.8;
 }
 
-.c51 {
+.c52 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -2231,16 +2284,16 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-radius: 4px;
 }
 
-.c51:hover {
+.c52:hover {
   opacity: 0.8;
 }
 
-.c1 {
+.c2 {
   width: 24;
   height: 24;
 }
 
-.c11 {
+.c12 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -2248,7 +2301,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c14 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -2259,7 +2312,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c19 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -2268,7 +2321,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -2276,15 +2329,16 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c48 {
+.c49 {
   color: #666666;
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
+  width: 100%;
 }
 
-.c28 {
+.c29 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -2293,7 +2347,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c43 {
+.c44 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1;
@@ -2301,7 +2355,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -2326,24 +2380,24 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c31:hover {
   background: #bacbf7;
   cursor: initial;
 }
 
-.c30:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   width: 100%;
   border-radius: 1px;
 }
 
-.c37 {
+.c38 {
   min-width: 0;
   box-sizing: border-box;
   top: 0px;
@@ -2373,7 +2427,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   background: #bacbf7;
 }
 
-.c46 {
+.c47 {
   min-width: 0;
   box-sizing: border-box;
   top: 0px;
@@ -2403,7 +2457,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   background: #d1ddfa;
 }
 
-.c36 {
+.c37 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -2421,6 +2475,8 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -2431,24 +2487,24 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   -moz-appearance: textfield;
 }
 
-.c36:hover {
+.c37:hover {
   background: #bacbf7;
   cursor: initial;
 }
 
-.c36:focus {
+.c37:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c36::-webkit-outer-spin-button,
-.c36::-webkit-inner-spin-button {
+.c37::-webkit-outer-spin-button,
+.c37::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.c45 {
+.c46 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -2475,24 +2531,24 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   -moz-appearance: textfield;
 }
 
-.c45:hover {
+.c46:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c45:focus {
+.c46:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c45::-webkit-outer-spin-button,
-.c45::-webkit-inner-spin-button {
+.c46::-webkit-outer-spin-button,
+.c46::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.c2 {
+.c3 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2510,7 +2566,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -2530,7 +2586,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c9 {
   margin-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2542,7 +2598,7 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   justify-content: space-between;
 }
 
-.c0 {
+.c1 {
   outline: 0;
   border: 0;
   background: transparent;
@@ -2550,496 +2606,504 @@ exports[`Send Flow snapshots it renders invalid value errors correctly 1`] = `
   transition: 0.24s ease-in-out;
   cursor: pointer;
   display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
 }
 
-.c0:hover {
+.c1:hover {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-@media screen and (min-width:40em) {
-  .c42 {
-    min-width: 160px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c42 {
-    min-width: 240px;
-  }
-}
-
 <div>
-  <button
+  <div
     class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
+    display="flex"
+    width="100%"
   >
-    <svg
+    <button
       class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      display="inline-block"
+      role="button"
+      type="button"
     >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
       class="c3"
-      display="flex"
-      width="13"
     >
       <div
         class="c4"
+        display="flex"
+        width="100%"
       >
         <div
           class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
         >
-          <ul
+          <div
             class="c6"
             display="flex"
-            width="100%"
+            overflow="hidden"
+            width="auto"
           >
-            <div
+            <ul
               class="c7"
               display="flex"
-            >
-              <li
-                class="c8"
-                display="flex"
-              >
-                <div
-                  class="c9"
-                  color="#000"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Sf
-                  </h3>
-                </div>
-              </li>
-              <li
-                class=""
-              >
-                <h2
-                  class="c11"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="4"
-                  font-weight="400"
-                >
-                  Sending Filecoin
-                </h2>
-              </li>
-            </div>
-            <li
-              class=""
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
-                <p
-                  class="c13"
-                  color="core.nearblack"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Step 
-                  3
-                </p>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-              </div>
-            </li>
-          </ul>
-          <div
-            class="c17"
-          >
-            <p
-              class="c18"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              Next, please review the transaction fee.
-            </p>
-          </div>
-        </div>
-        <div
-          class="c19"
-        >
-          <div
-            class="c20"
-            color="core.white"
-            width="100%"
-          >
-            <div
-              class="c21"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c22"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c23"
-                  display="flex"
-                >
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    From
-                  </p>
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    t1z225 ... 6z6wgi
-                  </p>
-                </div>
-              </div>
-              <div
-                class="c23"
-                display="flex"
-              >
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c25"
-            width="100%"
-          >
-            <div
-              class="c26"
-            >
-              <div
-                class="c14"
-                display="flex"
-              >
-                <div
-                  class="c27"
-                  display="flex"
-                >
-                  <h4
-                    class="c28"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Recipient
-                  </h4>
-                </div>
-                <div
-                  class="c29"
-                  display="flex"
-                >
-                  <input
-                    class="c30"
-                    disabled=""
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
-                    width="100%"
-                  />
-                  
-                </div>
-              </div>
-            </div>
-            
-          </div>
-          <div
-            class="c4"
-          >
-            <div
-              class="c31"
               width="100%"
             >
               <div
-                class="c32"
+                class="c8"
                 display="flex"
-                name="amount"
+              >
+                <li
+                  class="c9"
+                  display="flex"
+                >
+                  <div
+                    class="c10"
+                    color="#000"
+                    display="flex"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Sf
+                    </h3>
+                  </div>
+                </li>
+                <li
+                  class=""
+                >
+                  <h2
+                    class="c12"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="4"
+                    font-weight="400"
+                  >
+                    Sending Filecoin
+                  </h2>
+                </li>
+              </div>
+              <li
+                class=""
               >
                 <div
-                  class="c33"
-                  color="input.border"
+                  class="c13"
                   display="flex"
-                  width="100%"
                 >
-                  <h4
-                    class="c28"
+                  <p
+                    class="c14"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    Amount
-                  </h4>
+                    Step 
+                    3
+                  </p>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                 </div>
+              </li>
+            </ul>
+            <div
+              class="c18"
+            >
+              <p
+                class="c19"
+                font-family="RT-Alias-Grotesk"
+                font-size="2"
+                font-weight="400"
+              >
+                Next, please review the transaction fee.
+              </p>
+            </div>
+          </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21"
+              color="core.white"
+              width="100%"
+            >
+              <div
+                class="c22"
+                display="flex"
+              >
                 <div
-                  class="c34"
-                  display="inline-block"
-                  width="100%"
+                  class="c8"
+                  display="flex"
                 >
                   <div
-                    class="c35"
+                    class="c23"
+                    color="white"
                     display="flex"
-                    height="80px"
-                    width="100%"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Ms
+                    </h3>
+                  </div>
+                  <div
+                    class="c24"
+                    display="flex"
+                  >
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      From
+                    </p>
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c24"
+                  display="flex"
+                >
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Balance
+                  </p>
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    1
+                     FIL
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="c26"
+              width="100%"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c15"
+                  display="flex"
+                >
+                  <div
+                    class="c28"
+                    display="flex"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c30"
+                    display="flex"
                   >
                     <input
-                      class="c36"
+                      class="c31"
                       disabled=""
                       display="inline-block"
-                      font-size="5"
-                      height="100%"
-                      name="amount"
-                      placeholder="0"
-                      step="0.000000000000000001"
-                      type="number"
-                      value="0.01"
+                      height="6"
+                      placeholder="f1..."
+                      value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
                       width="100%"
                     />
-                    <div
-                      class="c37"
-                      color="core.primary"
-                      disabled=""
-                      display="flex"
-                      font-size="3"
-                      height="100%"
+                    
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              class="c5"
+            >
+              <div
+                class="c32"
+                width="100%"
+              >
+                <div
+                  class="c33"
+                  display="flex"
+                  name="amount"
+                >
+                  <div
+                    class="c34"
+                    color="input.border"
+                    display="flex"
+                    width="100%"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
                     >
-                      FIL
+                      Amount
+                    </h4>
+                  </div>
+                  <div
+                    class="c35"
+                    display="inline-block"
+                    width="100%"
+                  >
+                    <div
+                      class="c36"
+                      display="flex"
+                      height="80px"
+                      width="100%"
+                    >
+                      <input
+                        class="c37"
+                        disabled=""
+                        display="inline-block"
+                        font-size="5"
+                        height="100%"
+                        name="amount"
+                        placeholder="0"
+                        step="0.000000000000000001"
+                        type="number"
+                        value="0.01"
+                        width="100%"
+                      />
+                      <div
+                        class="c38"
+                        color="core.primary"
+                        disabled=""
+                        display="flex"
+                        font-size="3"
+                        height="100%"
+                      >
+                        FIL
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="c38"
-              width="100%"
-            >
               <div
                 class="c39"
-                display="flex"
+                width="100%"
               >
                 <div
                   class="c40"
                   display="flex"
                 >
                   <div
-                    class="c26"
-                    name="tx-fee"
+                    class="c41"
+                    display="flex"
                   >
                     <div
-                      class="c41"
-                      display="flex"
+                      class="c27"
+                      name="tx-fee"
                     >
                       <div
                         class="c42"
-                        display="inline-block"
-                      >
-                        <h4
-                          class="c43"
-                          font-family="RT-Alias-Grotesk"
-                          font-size="2"
-                          font-weight="400"
-                        >
-                          Transaction fee
-                        </h4>
-                      </div>
-                      <div
-                        class="c44"
-                        color="background.screen"
                         display="flex"
-                        width="100%"
                       >
-                        <input
-                          class="c45"
-                          display="inline-block"
-                          height="6"
-                          type="number"
-                          value="1000000"
-                          width="100%"
-                        />
                         <div
-                          class="c46"
-                          color="core.primary"
-                          display="flex"
-                          font-size="3"
-                          height="6"
+                          class="c43"
+                          display="inline-block"
                         >
-                          aFil
+                          <h4
+                            class="c44"
+                            font-family="RT-Alias-Grotesk"
+                            font-size="2"
+                            font-weight="400"
+                          >
+                            Transaction fee
+                          </h4>
+                        </div>
+                        <div
+                          class="c45"
+                          color="background.screen"
+                          display="flex"
+                          width="100%"
+                        >
+                          <input
+                            class="c46"
+                            display="inline-block"
+                            height="6"
+                            type="number"
+                            value="1000000"
+                            width="100%"
+                          />
+                          <div
+                            class="c47"
+                            color="core.primary"
+                            display="flex"
+                            font-size="3"
+                            height="6"
+                          >
+                            aFil
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    class="c47"
-                    display="flex"
-                    width="100%"
-                  >
-                    <p
+                    <div
                       class="c48"
-                      color="core.darkgray"
-                      font-family="RT-Alias-Grotesk"
-                      font-size="2"
-                      font-weight="400"
+                      display="flex"
+                      width="100%"
                     >
-                      *You will not pay more than 
-                      0.000000000001
-                       FIL for this transaction.
-                    </p>
+                      <p
+                        class="c49"
+                        color="core.darkgray"
+                        font-family="RT-Alias-Grotesk"
+                        font-size="2"
+                        font-weight="400"
+                        width="100%"
+                      >
+                        You will not pay more than 
+                        0.000000000001
+                         FIL for this transaction.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="c49"
-        display="flex"
-        width="13"
-      >
-        <button
+        <div
           class="c50"
-          font-size="3"
-          height="6"
-          type="button"
+          display="flex"
+          width="100%"
         >
-          Back
-        </button>
-        <button
-          class="c51"
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Next
-        </button>
+          <button
+            class="c51"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c52"
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Next
+          </button>
+        </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>
 `;
 
 exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
-.c3 {
+.c0 {
   min-width: 0;
   box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3050,18 +3114,18 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
-.c4 {
+.c5 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   min-width: 0;
   box-sizing: border-box;
   border: none;
@@ -3086,7 +3150,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -3102,7 +3166,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c10 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -3125,7 +3189,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c13 {
   min-width: 0;
   box-sizing: border-box;
   margin-left: 24px;
@@ -3137,7 +3201,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   display: flex;
 }
 
-.c14 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -3150,7 +3214,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -3162,7 +3226,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   height: 8px;
 }
 
-.c16 {
+.c17 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -3174,21 +3238,21 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   height: 8px;
 }
 
-.c17 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 48px;
   margin-bottom: 24px;
 }
 
-.c19 {
+.c20 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 16px;
   box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
 }
 
-.c20 {
+.c21 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -3200,7 +3264,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   width: 100%;
 }
 
-.c21 {
+.c22 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -3220,7 +3284,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c22 {
+.c23 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -3244,7 +3308,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -3260,7 +3324,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: flex-start;
 }
 
-.c25 {
+.c26 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -3269,7 +3333,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   width: 100%;
 }
 
-.c27 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   margin-right: 16px;
@@ -3288,7 +3352,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -3305,7 +3369,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: center;
 }
 
-.c38 {
+.c39 {
   min-width: 0;
   box-sizing: border-box;
   margin: auto;
@@ -3315,9 +3379,10 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -3335,7 +3400,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: flex-end;
 }
 
-.c31 {
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -3346,7 +3411,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   width: 100%;
 }
 
-.c32 {
+.c33 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -3362,7 +3427,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 4px;
@@ -3391,14 +3456,14 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   text-align: center;
 }
 
-.c34 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
   display: inline-block;
   width: 100%;
 }
 
-.c35 {
+.c36 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -3413,13 +3478,13 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   width: 100%;
 }
 
-.c10 {
+.c11 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c39 {
+.c40 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -3438,11 +3503,11 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   border-radius: 4px;
 }
 
-.c39:hover {
+.c40:hover {
   opacity: 0.8;
 }
 
-.c40 {
+.c41 {
   cursor: not-allowed;
   border: 1px solid #C4C4C4;
   background-color: #C4C4C4;
@@ -3460,16 +3525,16 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   border-radius: 4px;
 }
 
-.c40:hover {
+.c41:hover {
   opacity: 1;
 }
 
-.c1 {
+.c2 {
   width: 24;
   height: 24;
 }
 
-.c11 {
+.c12 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -3477,7 +3542,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c14 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -3488,7 +3553,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c19 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -3497,7 +3562,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -3505,7 +3570,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   margin: 0;
 }
 
-.c28 {
+.c29 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -3514,7 +3579,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -3539,24 +3604,24 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c31:hover {
   background: #bacbf7;
   cursor: initial;
 }
 
-.c30:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   width: 100%;
   border-radius: 1px;
 }
 
-.c37 {
+.c38 {
   min-width: 0;
   box-sizing: border-box;
   top: 0px;
@@ -3586,7 +3651,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   background: #d1ddfa;
 }
 
-.c36 {
+.c37 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -3604,6 +3669,8 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -3614,24 +3681,24 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   -moz-appearance: textfield;
 }
 
-.c36:hover {
+.c37:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c36:focus {
+.c37:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c36::-webkit-outer-spin-button,
-.c36::-webkit-inner-spin-button {
+.c37::-webkit-outer-spin-button,
+.c37::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.c2 {
+.c3 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3649,7 +3716,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3669,7 +3736,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c9 {
   margin-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3681,7 +3748,7 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c0 {
+.c1 {
   outline: 0;
   border: 0;
   background: transparent;
@@ -3689,361 +3756,367 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
   transition: 0.24s ease-in-out;
   cursor: pointer;
   display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
 }
 
-.c0:hover {
+.c1:hover {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
 <div>
-  <button
+  <div
     class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
+    display="flex"
+    width="100%"
   >
-    <svg
+    <button
       class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      display="inline-block"
+      role="button"
+      type="button"
     >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
       class="c3"
-      display="flex"
-      width="13"
     >
       <div
         class="c4"
+        display="flex"
+        width="100%"
       >
         <div
           class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
         >
-          <ul
+          <div
             class="c6"
             display="flex"
-            width="100%"
+            overflow="hidden"
+            width="auto"
           >
-            <div
+            <ul
               class="c7"
               display="flex"
-            >
-              <li
-                class="c8"
-                display="flex"
-              >
-                <div
-                  class="c9"
-                  color="#000"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Sf
-                  </h3>
-                </div>
-              </li>
-              <li
-                class=""
-              >
-                <h2
-                  class="c11"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="4"
-                  font-weight="400"
-                >
-                  Sending Filecoin
-                </h2>
-              </li>
-            </div>
-            <li
-              class=""
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
-                <p
-                  class="c13"
-                  color="core.nearblack"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Step 
-                  2
-                </p>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
-                  <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-              </div>
-            </li>
-          </ul>
-          <div
-            class="c17"
-          >
-            <p
-              class="c18"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
-            >
-              Next, please choose an amount of FIL you'd like to withdraw.
-            </p>
-          </div>
-        </div>
-        <div
-          class="c19"
-        >
-          <div
-            class="c20"
-            color="core.white"
-            width="100%"
-          >
-            <div
-              class="c21"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c22"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c23"
-                  display="flex"
-                >
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    From
-                  </p>
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    t1z225 ... 6z6wgi
-                  </p>
-                </div>
-              </div>
-              <div
-                class="c23"
-                display="flex"
-              >
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c25"
-            width="100%"
-          >
-            <div
-              class="c26"
-            >
-              <div
-                class="c14"
-                display="flex"
-              >
-                <div
-                  class="c27"
-                  display="flex"
-                >
-                  <h4
-                    class="c28"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Recipient
-                  </h4>
-                </div>
-                <div
-                  class="c29"
-                  display="flex"
-                >
-                  <input
-                    class="c30"
-                    disabled=""
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
-                    width="100%"
-                  />
-                  
-                </div>
-              </div>
-            </div>
-            
-          </div>
-          <div
-            class="c4"
-          >
-            <div
-              class="c31"
               width="100%"
             >
               <div
-                class="c32"
+                class="c8"
                 display="flex"
-                name="amount"
+              >
+                <li
+                  class="c9"
+                  display="flex"
+                >
+                  <div
+                    class="c10"
+                    color="#000"
+                    display="flex"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Sf
+                    </h3>
+                  </div>
+                </li>
+                <li
+                  class=""
+                >
+                  <h2
+                    class="c12"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="4"
+                    font-weight="400"
+                  >
+                    Sending Filecoin
+                  </h2>
+                </li>
+              </div>
+              <li
+                class=""
               >
                 <div
-                  class="c33"
-                  color="input.border"
+                  class="c13"
                   display="flex"
-                  width="100%"
                 >
-                  <h4
-                    class="c28"
+                  <p
+                    class="c14"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    Amount
-                  </h4>
+                    Step 
+                    2
+                  </p>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                 </div>
+              </li>
+            </ul>
+            <div
+              class="c18"
+            >
+              <p
+                class="c19"
+                font-family="RT-Alias-Grotesk"
+                font-size="2"
+                font-weight="400"
+              >
+                Next, please choose an amount of FIL you'd like to withdraw.
+              </p>
+            </div>
+          </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21"
+              color="core.white"
+              width="100%"
+            >
+              <div
+                class="c22"
+                display="flex"
+              >
                 <div
-                  class="c34"
-                  display="inline-block"
-                  width="100%"
+                  class="c8"
+                  display="flex"
                 >
                   <div
-                    class="c35"
+                    class="c23"
+                    color="white"
                     display="flex"
-                    height="80px"
-                    width="100%"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Ms
+                    </h3>
+                  </div>
+                  <div
+                    class="c24"
+                    display="flex"
+                  >
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      From
+                    </p>
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c24"
+                  display="flex"
+                >
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Balance
+                  </p>
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    1
+                     FIL
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="c26"
+              width="100%"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c15"
+                  display="flex"
+                >
+                  <div
+                    class="c28"
+                    display="flex"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c30"
+                    display="flex"
                   >
                     <input
-                      class="c36"
+                      class="c31"
+                      disabled=""
                       display="inline-block"
-                      font-size="5"
-                      height="100%"
-                      name="amount"
-                      placeholder="0"
-                      step="0.000000000000000001"
-                      type="number"
-                      value=""
+                      height="6"
+                      placeholder="f1..."
+                      value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
                       width="100%"
                     />
-                    <div
-                      class="c37"
-                      color="core.primary"
-                      display="flex"
-                      font-size="3"
-                      height="100%"
+                    
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              class="c5"
+            >
+              <div
+                class="c32"
+                width="100%"
+              >
+                <div
+                  class="c33"
+                  display="flex"
+                  name="amount"
+                >
+                  <div
+                    class="c34"
+                    color="input.border"
+                    display="flex"
+                    width="100%"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
                     >
-                      FIL
+                      Amount
+                    </h4>
+                  </div>
+                  <div
+                    class="c35"
+                    display="inline-block"
+                    width="100%"
+                  >
+                    <div
+                      class="c36"
+                      display="flex"
+                      height="80px"
+                      width="100%"
+                    >
+                      <input
+                        class="c37"
+                        display="inline-block"
+                        font-size="5"
+                        height="100%"
+                        name="amount"
+                        placeholder="0"
+                        step="0.000000000000000001"
+                        type="number"
+                        value=""
+                        width="100%"
+                      />
+                      <div
+                        class="c38"
+                        color="core.primary"
+                        display="flex"
+                        font-size="3"
+                        height="100%"
+                      >
+                        FIL
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -4051,42 +4124,55 @@ exports[`Send Flow snapshots it renders step 2 correctly 1`] = `
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="c38"
-        display="flex"
-        width="13"
-      >
-        <button
+        <div
           class="c39"
-          font-size="3"
-          height="6"
-          type="button"
+          display="flex"
+          width="100%"
         >
-          Back
-        </button>
-        <button
-          class="c40"
-          disabled=""
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Next
-        </button>
+          <button
+            class="c40"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c41"
+            disabled=""
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Next
+          </button>
+        </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>
 `;
 
 exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
-.c3 {
+.c0 {
   min-width: 0;
   box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4097,18 +4183,18 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
-.c4 {
+.c5 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   min-width: 0;
   box-sizing: border-box;
   border: none;
@@ -4133,7 +4219,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -4149,7 +4235,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c10 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -4172,7 +4258,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c13 {
   min-width: 0;
   box-sizing: border-box;
   margin-left: 24px;
@@ -4184,7 +4270,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   display: flex;
 }
 
-.c14 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -4197,7 +4283,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -4209,7 +4295,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   height: 8px;
 }
 
-.c16 {
+.c17 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 100px;
@@ -4221,21 +4307,21 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   height: 8px;
 }
 
-.c17 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   margin-top: 48px;
   margin-bottom: 24px;
 }
 
-.c19 {
+.c20 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 16px;
   box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
 }
 
-.c20 {
+.c21 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -4247,7 +4333,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   width: 100%;
 }
 
-.c21 {
+.c22 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -4267,7 +4353,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c22 {
+.c23 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -4291,7 +4377,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -4307,7 +4393,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: flex-start;
 }
 
-.c25 {
+.c26 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -4316,7 +4402,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   width: 100%;
 }
 
-.c27 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   margin-right: 16px;
@@ -4335,7 +4421,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -4352,7 +4438,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c50 {
   min-width: 0;
   box-sizing: border-box;
   margin: auto;
@@ -4362,9 +4448,10 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -4382,7 +4469,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: flex-end;
 }
 
-.c38 {
+.c39 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -4393,7 +4480,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   width: 100%;
 }
 
-.c32 {
+.c33 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -4409,7 +4496,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 4px;
@@ -4438,14 +4525,14 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   text-align: center;
 }
 
-.c34 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
   display: inline-block;
   width: 100%;
 }
 
-.c35 {
+.c36 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -4460,7 +4547,1348 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   width: 100%;
 }
 
+.c32 {
+  min-width: 0;
+  box-sizing: border-box;
+  border: 0;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #EFF3FD;
+  width: 100%;
+}
+
+.c40 {
+  min-width: 0;
+  box-sizing: border-box;
+  background-color: #EFF3FD;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c41 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 560px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c42 {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c43 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-right: 8px;
+  display: inline-block;
+  min-width: 240px;
+  text-align: left;
+}
+
+.c45 {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+  border-bottom: 1px solid;
+  border-top: 1px solid;
+  color: #EFF3FD;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c48 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  text-align: left;
+}
+
+.c11 {
+  font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.c51 {
+  cursor: pointer;
+  border: 1px solid #262626;
+  background-color: transparent;
+  border-color: #262626;
+  color: #262626;
+  font-size: 1.125rem;
+  -webkit-transition: 0.18s ease-in-out;
+  transition: 0.18s ease-in-out;
+  border-radius: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: 48px;
+  border-width: 1px;
+  border-radius: 4px;
+}
+
+.c51:hover {
+  opacity: 0.8;
+}
+
+.c52 {
+  cursor: pointer;
+  border: 1px solid #1AD08F;
+  background-color: #1AD08F;
+  border-color: #1AD08F;
+  color: #08442F;
+  font-size: 1.125rem;
+  -webkit-transition: 0.18s ease-in-out;
+  transition: 0.18s ease-in-out;
+  border-radius: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: 48px;
+  border-width: 1px;
+  border-radius: 4px;
+}
+
+.c52:hover {
+  opacity: 0.8;
+}
+
+.c2 {
+  width: 24;
+  height: 24;
+}
+
+.c12 {
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1.2;
+  font-family: RT-Alias-Grotesk;
+  margin: 0;
+}
+
+.c14 {
+  color: #262626;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c19 {
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  text-align: center;
+  margin: 0;
+}
+
+.c25 {
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  margin: 0;
+}
+
+.c49 {
+  color: #666666;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  width: 100%;
+}
+
+.c29 {
+  color: #262626;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1;
+  font-family: RT-Alias-Grotesk;
+  margin: 0;
+}
+
+.c44 {
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1;
+  font-family: RT-Alias-Grotesk;
+  margin: 0;
+}
+
 .c31 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: left;
+  cursor: text;
+  background: #bacbf7;
+  padding-left: 16px;
+  padding-right: 16px;
+  display: inline-block;
+  height: 48px;
+  width: 100%;
+  border-radius: 4px;
+  border: 0;
+  border-color: #999999;
+}
+
+.c31:hover {
+  background: #bacbf7;
+  cursor: initial;
+}
+
+.c31:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c27 {
+  display: inline-block;
+  width: 100%;
+  border-radius: 1px;
+}
+
+.c38 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #bacbf7;
+}
+
+.c47 {
+  min-width: 0;
+  box-sizing: border-box;
+  top: 0px;
+  left: 0px;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #5E26FF;
+  height: 48px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 64px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  text-align: center;
+  position: relative;
+  background: #d1ddfa;
+}
+
+.c37 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: left;
+  cursor: text;
+  background: #bacbf7;
+  font-size: 2rem;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: 100%;
+  display: inline-block;
+  width: 100%;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  -moz-appearance: textfield;
+}
+
+.c37:hover {
+  background: #bacbf7;
+  cursor: initial;
+}
+
+.c37:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c37::-webkit-outer-spin-button,
+.c37::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c46 {
+  min-width: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: 1px;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: left;
+  cursor: text;
+  background: #d1ddfa;
+  padding-left: 16px;
+  padding-right: 16px;
+  display: inline-block;
+  height: 48px;
+  width: 100%;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  border: 0;
+  border-color: #999999;
+  -moz-appearance: textfield;
+}
+
+.c46:hover {
+  background: #bacbf7;
+  cursor: text;
+}
+
+.c46:focus {
+  box-shadow: 0;
+  outline: 0;
+  background: #bacbf7;
+}
+
+.c46::-webkit-outer-spin-button,
+.c46::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  border-color: silver;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c9 {
+  margin-right: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c1 {
+  outline: 0;
+  border: 0;
+  background: transparent;
+  -webkit-transition: 0.24s ease-in-out;
+  transition: 0.24s ease-in-out;
+  cursor: pointer;
+  display: inline-block;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
+}
+
+.c1:hover {
+  -webkit-transform: scale(1.25);
+  -ms-transform: scale(1.25);
+  transform: scale(1.25);
+}
+
+<div>
+  <div
+    class="c0"
+    display="flex"
+    width="100%"
+  >
+    <button
+      class="c1"
+      display="inline-block"
+      role="button"
+      type="button"
+    >
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
+      class="c3"
+    >
+      <div
+        class="c4"
+        display="flex"
+        width="100%"
+      >
+        <div
+          class="c5"
+        >
+          <div
+            class="c6"
+            display="flex"
+            overflow="hidden"
+            width="auto"
+          >
+            <ul
+              class="c7"
+              display="flex"
+              width="100%"
+            >
+              <div
+                class="c8"
+                display="flex"
+              >
+                <li
+                  class="c9"
+                  display="flex"
+                >
+                  <div
+                    class="c10"
+                    color="#000"
+                    display="flex"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Sf
+                    </h3>
+                  </div>
+                </li>
+                <li
+                  class=""
+                >
+                  <h2
+                    class="c12"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="4"
+                    font-weight="400"
+                  >
+                    Sending Filecoin
+                  </h2>
+                </li>
+              </div>
+              <li
+                class=""
+              >
+                <div
+                  class="c13"
+                  display="flex"
+                >
+                  <p
+                    class="c14"
+                    color="core.nearblack"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Step 
+                    3
+                  </p>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                  <div
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
+                </div>
+              </li>
+            </ul>
+            <div
+              class="c18"
+            >
+              <p
+                class="c19"
+                font-family="RT-Alias-Grotesk"
+                font-size="2"
+                font-weight="400"
+              >
+                Next, please review the transaction fee.
+              </p>
+            </div>
+          </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21"
+              color="core.white"
+              width="100%"
+            >
+              <div
+                class="c22"
+                display="flex"
+              >
+                <div
+                  class="c8"
+                  display="flex"
+                >
+                  <div
+                    class="c23"
+                    color="white"
+                    display="flex"
+                    size="6"
+                  >
+                    <h3
+                      class="c11"
+                    >
+                      Ms
+                    </h3>
+                  </div>
+                  <div
+                    class="c24"
+                    display="flex"
+                  >
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      From
+                    </p>
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c24"
+                  display="flex"
+                >
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Balance
+                  </p>
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    1
+                     FIL
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="c26"
+              width="100%"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c15"
+                  display="flex"
+                >
+                  <div
+                    class="c28"
+                    display="flex"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c30"
+                    display="flex"
+                  >
+                    <input
+                      class="c31"
+                      disabled=""
+                      display="inline-block"
+                      height="6"
+                      placeholder="f1..."
+                      value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
+                      width="100%"
+                    />
+                    
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              class="c5"
+            >
+              <div
+                class="c32"
+                width="100%"
+              >
+                <div
+                  class="c33"
+                  display="flex"
+                  name="amount"
+                >
+                  <div
+                    class="c34"
+                    color="input.border"
+                    display="flex"
+                    width="100%"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Amount
+                    </h4>
+                  </div>
+                  <div
+                    class="c35"
+                    display="inline-block"
+                    width="100%"
+                  >
+                    <div
+                      class="c36"
+                      display="flex"
+                      height="80px"
+                      width="100%"
+                    >
+                      <input
+                        class="c37"
+                        disabled=""
+                        display="inline-block"
+                        font-size="5"
+                        height="100%"
+                        name="amount"
+                        placeholder="0"
+                        step="0.000000000000000001"
+                        type="number"
+                        value="0.01"
+                        width="100%"
+                      />
+                      <div
+                        class="c38"
+                        color="core.primary"
+                        disabled=""
+                        display="flex"
+                        font-size="3"
+                        height="100%"
+                      >
+                        FIL
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c39"
+                width="100%"
+              >
+                <div
+                  class="c40"
+                  display="flex"
+                >
+                  <div
+                    class="c41"
+                    display="flex"
+                  >
+                    <div
+                      class="c27"
+                      name="tx-fee"
+                    >
+                      <div
+                        class="c42"
+                        display="flex"
+                      >
+                        <div
+                          class="c43"
+                          display="inline-block"
+                        >
+                          <h4
+                            class="c44"
+                            font-family="RT-Alias-Grotesk"
+                            font-size="2"
+                            font-weight="400"
+                          >
+                            Transaction fee
+                          </h4>
+                        </div>
+                        <div
+                          class="c45"
+                          color="background.screen"
+                          display="flex"
+                          width="100%"
+                        >
+                          <input
+                            class="c46"
+                            display="inline-block"
+                            height="6"
+                            type="number"
+                            value="1000000"
+                            width="100%"
+                          />
+                          <div
+                            class="c47"
+                            color="core.primary"
+                            display="flex"
+                            font-size="3"
+                            height="6"
+                          >
+                            aFil
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c48"
+                      display="flex"
+                      width="100%"
+                    >
+                      <p
+                        class="c49"
+                        color="core.darkgray"
+                        font-family="RT-Alias-Grotesk"
+                        font-size="2"
+                        font-weight="400"
+                        width="100%"
+                      >
+                        You will not pay more than 
+                        0.000000000001
+                         FIL for this transaction.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c50"
+          display="flex"
+          width="100%"
+        >
+          <button
+            class="c51"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c52"
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
+.c0 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c5 {
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.c6 {
+  min-width: 0;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  border-width: 1px;
+  padding: 16px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  background-color: #d9e0f2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: auto;
+  overflow: hidden;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c8 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-width: 0.1875rem;
+  border-radius: 8px;
+  border-style: solid;
+  color: #000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 48px;
+  height: 48px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c13 {
+  min-width: 0;
+  box-sizing: border-box;
+  margin-left: 24px;
+  margin-top: 0;
+  margin-bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c16 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 100px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: #1AD08F;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+}
+
+.c17 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 100px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: #C4C4C4;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+}
+
+.c18 {
+  min-width: 0;
+  box-sizing: border-box;
+  margin-top: 48px;
+  margin-bottom: 24px;
+}
+
+.c20 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 16px;
+  box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
+}
+
+.c21 {
+  min-width: 0;
+  box-sizing: border-box;
+  border: 0;
+  border-top-right-radius: 8px;
+  border-top-left-radius: 8px;
+  padding: 16px;
+  background-color: #5E26FF;
+  color: #ffffff;
+  width: 100%;
+}
+
+.c22 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c23 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-width: 0.1875rem;
+  border-radius: 8px;
+  border-style: solid;
+  margin-right: 16px;
+  color: white;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 48px;
+  height: 48px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c24 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c26 {
+  min-width: 0;
+  box-sizing: border-box;
+  border: 0;
+  padding: 16px;
+  background-color: #EFF3FD;
+  width: 100%;
+}
+
+.c28 {
+  min-width: 0;
+  box-sizing: border-box;
+  margin-right: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-width: 48px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c30 {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c53 {
+  min-width: 0;
+  box-sizing: border-box;
+  margin: auto;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c33 {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+  border-color: #999999;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 120px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c34 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 4px;
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-right: 8px;
+  color: #999999;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  max-width: 240px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  text-align: center;
+}
+
+.c35 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: inline-block;
+  width: 100%;
+}
+
+.c36 {
+  min-width: 0;
+  box-sizing: border-box;
+  position: relative;
+  border-bottom: 1px solid;
+  border-color: #EFF3FD;
+  border-top-left-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 80px;
+  width: 100%;
+}
+
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   border: 0;
@@ -4533,7 +5961,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   padding-right: 8px;
   margin-right: 8px;
   display: inline-block;
-  min-width: 160px;
+  min-width: 240px;
   text-align: left;
 }
 
@@ -4562,22 +5990,62 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 280px;
   width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
   text-align: left;
 }
 
-.c10 {
+.c49 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  padding-top: 48px;
+  padding-bottom: 32px;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: #EFF3FD;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c50 {
+  min-width: 0;
+  box-sizing: border-box;
+  padding-left: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  text-align: right;
+}
+
+.c11 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c50 {
+.c54 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -4596,11 +6064,11 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   border-radius: 4px;
 }
 
-.c50:hover {
+.c54:hover {
   opacity: 0.8;
 }
 
-.c51 {
+.c55 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -4619,16 +6087,16 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   border-radius: 4px;
 }
 
-.c51:hover {
+.c55:hover {
   opacity: 0.8;
 }
 
-.c1 {
+.c2 {
   width: 24;
   height: 24;
 }
 
-.c11 {
+.c12 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -4636,7 +6104,16 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c51 {
+  color: #5E26FF;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  font-family: RT-Alias-Grotesk;
+  margin: 0;
+}
+
+.c14 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -4647,7 +6124,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c19 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -4656,7 +6133,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -4670,9 +6147,10 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   font-weight: 400;
   line-height: 1.4;
   font-family: RT-Alias-Grotesk;
+  width: 100%;
 }
 
-.c28 {
+.c29 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -4689,7 +6167,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   margin: 0;
 }
 
-.c30 {
+.c31 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -4714,24 +6192,24 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   border-color: #999999;
 }
 
-.c30:hover {
+.c31:hover {
   background: #bacbf7;
   cursor: initial;
 }
 
-.c30:focus {
+.c31:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   width: 100%;
   border-radius: 1px;
 }
 
-.c37 {
+.c38 {
   min-width: 0;
   box-sizing: border-box;
   top: 0px;
@@ -4791,7 +6269,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   background: #d1ddfa;
 }
 
-.c36 {
+.c37 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -4809,6 +6287,8 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -4819,19 +6299,19 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   -moz-appearance: textfield;
 }
 
-.c36:hover {
+.c37:hover {
   background: #bacbf7;
   cursor: initial;
 }
 
-.c36:focus {
+.c37:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c36::-webkit-outer-spin-button,
-.c36::-webkit-inner-spin-button {
+.c37::-webkit-outer-spin-button,
+.c37::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -4880,7 +6360,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   margin: 0;
 }
 
-.c2 {
+.c3 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4898,7 +6378,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -4918,7 +6398,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c9 {
   margin-right: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4930,7 +6410,7 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c0 {
+.c1 {
   outline: 0;
   border: 0;
   background: transparent;
@@ -4938,496 +6418,536 @@ exports[`Send Flow snapshots it renders step 3 correctly 1`] = `
   transition: 0.24s ease-in-out;
   cursor: pointer;
   display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
 }
 
-.c0:hover {
+.c1:hover {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-@media screen and (min-width:40em) {
-  .c42 {
-    min-width: 160px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c42 {
-    min-width: 240px;
-  }
+.c52 {
+  word-wrap: break-word;
 }
 
 <div>
-  <button
+  <div
     class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
+    display="flex"
+    width="100%"
   >
-    <svg
+    <button
       class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      display="inline-block"
+      role="button"
+      type="button"
     >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
       class="c3"
-      display="flex"
-      width="13"
     >
       <div
         class="c4"
+        display="flex"
+        width="100%"
       >
         <div
           class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
         >
-          <ul
+          <div
             class="c6"
             display="flex"
-            width="100%"
+            overflow="hidden"
+            width="auto"
           >
-            <div
+            <ul
               class="c7"
               display="flex"
+              width="100%"
             >
-              <li
+              <div
                 class="c8"
                 display="flex"
               >
-                <div
+                <li
                   class="c9"
-                  color="#000"
                   display="flex"
-                  size="6"
                 >
-                  <h3
+                  <div
                     class="c10"
+                    color="#000"
+                    display="flex"
+                    size="6"
                   >
-                    Sf
-                  </h3>
-                </div>
-              </li>
+                    <h3
+                      class="c11"
+                    >
+                      Sf
+                    </h3>
+                  </div>
+                </li>
+                <li
+                  class=""
+                >
+                  <h2
+                    class="c12"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="4"
+                    font-weight="400"
+                  >
+                    Sending Filecoin
+                  </h2>
+                </li>
+              </div>
               <li
                 class=""
               >
-                <h2
-                  class="c11"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="4"
-                  font-weight="400"
-                >
-                  Sending Filecoin
-                </h2>
-              </li>
-            </div>
-            <li
-              class=""
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
-                <p
+                <div
                   class="c13"
-                  color="core.nearblack"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Step 
-                  3
-                </p>
-                <div
-                  class="c14"
                   display="flex"
                 >
+                  <p
+                    class="c14"
+                    color="core.nearblack"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Step 
+                    4
+                  </p>
                   <div
                     class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
                     class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
                     class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c16"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
+                    class="c15"
+                    display="flex"
+                  >
+                    <div
+                      class="c17"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                 </div>
-              </div>
-            </li>
-          </ul>
-          <div
-            class="c17"
-          >
-            <p
+              </li>
+            </ul>
+            <div
               class="c18"
-              font-family="RT-Alias-Grotesk"
-              font-size="2"
-              font-weight="400"
             >
-              Next, please review the transaction fee.
-            </p>
+              <p
+                class="c19"
+                font-family="RT-Alias-Grotesk"
+                font-size="2"
+                font-weight="400"
+              >
+                Please review the transaction details.
+              </p>
+            </div>
           </div>
-        </div>
-        <div
-          class="c19"
-        >
           <div
             class="c20"
-            color="core.white"
-            width="100%"
           >
             <div
               class="c21"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c22"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c23"
-                  display="flex"
-                >
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    From
-                  </p>
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    t1z225 ... 6z6wgi
-                  </p>
-                </div>
-              </div>
-              <div
-                class="c23"
-                display="flex"
-              >
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c25"
-            width="100%"
-          >
-            <div
-              class="c26"
-            >
-              <div
-                class="c14"
-                display="flex"
-              >
-                <div
-                  class="c27"
-                  display="flex"
-                >
-                  <h4
-                    class="c28"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Recipient
-                  </h4>
-                </div>
-                <div
-                  class="c29"
-                  display="flex"
-                >
-                  <input
-                    class="c30"
-                    disabled=""
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
-                    width="100%"
-                  />
-                  
-                </div>
-              </div>
-            </div>
-            
-          </div>
-          <div
-            class="c4"
-          >
-            <div
-              class="c31"
+              color="core.white"
               width="100%"
             >
               <div
-                class="c32"
-                display="flex"
-                name="amount"
-              >
-                <div
-                  class="c33"
-                  color="input.border"
-                  display="flex"
-                  width="100%"
-                >
-                  <h4
-                    class="c28"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Amount
-                  </h4>
-                </div>
-                <div
-                  class="c34"
-                  display="inline-block"
-                  width="100%"
-                >
-                  <div
-                    class="c35"
-                    display="flex"
-                    height="80px"
-                    width="100%"
-                  >
-                    <input
-                      class="c36"
-                      disabled=""
-                      display="inline-block"
-                      font-size="5"
-                      height="100%"
-                      name="amount"
-                      placeholder="0"
-                      step="0.000000000000000001"
-                      type="number"
-                      value="0.01"
-                      width="100%"
-                    />
-                    <div
-                      class="c37"
-                      color="core.primary"
-                      disabled=""
-                      display="flex"
-                      font-size="3"
-                      height="100%"
-                    >
-                      FIL
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="c38"
-              width="100%"
-            >
-              <div
-                class="c39"
+                class="c22"
                 display="flex"
               >
                 <div
-                  class="c40"
+                  class="c8"
                   display="flex"
                 >
                   <div
-                    class="c26"
-                    name="tx-fee"
+                    class="c23"
+                    color="white"
+                    display="flex"
+                    size="6"
                   >
-                    <div
-                      class="c41"
-                      display="flex"
+                    <h3
+                      class="c11"
                     >
-                      <div
-                        class="c42"
-                        display="inline-block"
-                      >
-                        <h4
-                          class="c43"
-                          font-family="RT-Alias-Grotesk"
-                          font-size="2"
-                          font-weight="400"
-                        >
-                          Transaction fee
-                        </h4>
-                      </div>
-                      <div
-                        class="c44"
-                        color="background.screen"
-                        display="flex"
-                        width="100%"
-                      >
-                        <input
-                          class="c45"
-                          display="inline-block"
-                          height="6"
-                          type="number"
-                          value="1000000"
-                          width="100%"
-                        />
-                        <div
-                          class="c46"
-                          color="core.primary"
-                          display="flex"
-                          font-size="3"
-                          height="6"
-                        >
-                          aFil
-                        </div>
-                      </div>
-                    </div>
+                      Ms
+                    </h3>
                   </div>
                   <div
-                    class="c47"
+                    class="c24"
                     display="flex"
-                    width="100%"
                   >
                     <p
-                      class="c48"
-                      color="core.darkgray"
+                      class="c25"
                       font-family="RT-Alias-Grotesk"
                       font-size="2"
                       font-weight="400"
                     >
-                      *You will not pay more than 
-                      0.000000000001
-                       FIL for this transaction.
+                      From
                     </p>
+                    <p
+                      class="c25"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="c24"
+                  display="flex"
+                >
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Balance
+                  </p>
+                  <p
+                    class="c25"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    1
+                     FIL
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="c26"
+              width="100%"
+            >
+              <div
+                class="c27"
+              >
+                <div
+                  class="c15"
+                  display="flex"
+                >
+                  <div
+                    class="c28"
+                    display="flex"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c30"
+                    display="flex"
+                  >
+                    <input
+                      class="c31"
+                      disabled=""
+                      display="inline-block"
+                      height="6"
+                      placeholder="f1..."
+                      value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
+                      width="100%"
+                    />
+                    
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              class="c5"
+            >
+              <div
+                class="c32"
+                width="100%"
+              >
+                <div
+                  class="c33"
+                  display="flex"
+                  name="amount"
+                >
+                  <div
+                    class="c34"
+                    color="input.border"
+                    display="flex"
+                    width="100%"
+                  >
+                    <h4
+                      class="c29"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Amount
+                    </h4>
+                  </div>
+                  <div
+                    class="c35"
+                    display="inline-block"
+                    width="100%"
+                  >
+                    <div
+                      class="c36"
+                      display="flex"
+                      height="80px"
+                      width="100%"
+                    >
+                      <input
+                        class="c37"
+                        disabled=""
+                        display="inline-block"
+                        font-size="5"
+                        height="100%"
+                        name="amount"
+                        placeholder="0"
+                        step="0.000000000000000001"
+                        type="number"
+                        value="0.01"
+                        width="100%"
+                      />
+                      <div
+                        class="c38"
+                        color="core.primary"
+                        disabled=""
+                        display="flex"
+                        font-size="3"
+                        height="100%"
+                      >
+                        FIL
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c32"
+                width="100%"
+              >
+                <div
+                  class="c39"
+                  display="flex"
+                >
+                  <div
+                    class="c40"
+                    display="flex"
+                  >
+                    <div
+                      class="c27"
+                      name="tx-fee"
+                    >
+                      <div
+                        class="c41"
+                        display="flex"
+                      >
+                        <div
+                          class="c42"
+                          display="inline-block"
+                        >
+                          <h4
+                            class="c43"
+                            font-family="RT-Alias-Grotesk"
+                            font-size="2"
+                            font-weight="400"
+                          >
+                            Transaction fee
+                          </h4>
+                        </div>
+                        <div
+                          class="c44"
+                          color="background.screen"
+                          display="flex"
+                          width="100%"
+                        >
+                          <input
+                            class="c45"
+                            display="inline-block"
+                            height="6"
+                            type="number"
+                            value="1000000"
+                            width="100%"
+                          />
+                          <div
+                            class="c46"
+                            color="core.primary"
+                            display="flex"
+                            font-size="3"
+                            height="6"
+                          >
+                            aFil
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c47"
+                      display="flex"
+                      width="100%"
+                    >
+                      <p
+                        class="c48"
+                        color="core.darkgray"
+                        font-family="RT-Alias-Grotesk"
+                        font-size="2"
+                        font-weight="400"
+                        width="100%"
+                      >
+                        You will not pay more than 
+                        0.000000000001
+                         FIL for this transaction.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
+            <div
+              class="c49"
+              display="flex"
+            >
+              <h2
+                class="c12"
+                font-family="RT-Alias-Grotesk"
+                font-size="4"
+                font-weight="400"
+              >
+                Total
+              </h2>
+              <div
+                class="c50"
+                display="flex"
+              >
+                <h2
+                  class="c51 c52"
+                  color="core.primary"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="5"
+                  font-weight="700"
+                >
+                  0.01
+                   FIL
+                </h2>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        class="c49"
-        display="flex"
-        width="13"
-      >
-        <button
-          class="c50"
-          font-size="3"
-          height="6"
-          type="button"
+        <div
+          class="c53"
+          display="flex"
+          width="100%"
         >
-          Back
-        </button>
-        <button
-          class="c51"
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Next
-        </button>
+          <button
+            class="c54"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c55"
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Next
+          </button>
+        </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>
 `;
 
-exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
-.c3 {
+exports[`Send Flow snapshots it renders step 5 correctly 1`] = `
+.c0 {
   min-width: 0;
   box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  min-width: 0;
+  box-sizing: border-box;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5438,43 +6958,18 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  min-width: 0;
-  box-sizing: border-box;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
 .c5 {
   min-width: 0;
   box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  border-width: 1px;
-  padding: 16px;
-  margin-top: 8px;
-  margin-bottom: 8px;
-  background-color: #d9e0f2;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: auto;
-  overflow: hidden;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
 }
 
-.c7 {
+.c8 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -5490,44 +6985,9 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   align-items: center;
 }
 
-.c9 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-width: 0.1875rem;
-  border-radius: 8px;
-  border-style: solid;
-  color: #000;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 48px;
-  height: 48px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
 .c12 {
   min-width: 0;
   box-sizing: border-box;
-  margin-left: 24px;
-  margin-top: 0;
-  margin-bottom: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c14 {
-  min-width: 0;
-  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5536,37 +6996,6 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c15 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-radius: 100px;
-  margin-left: 4px;
-  margin-right: 4px;
-  background-color: #1AD08F;
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-}
-
-.c16 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-radius: 100px;
-  margin-left: 4px;
-  margin-right: 4px;
-  background-color: #C4C4C4;
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-}
-
-.c17 {
-  min-width: 0;
-  box-sizing: border-box;
-  margin-top: 48px;
-  margin-bottom: 24px;
 }
 
 .c19 {
@@ -5693,7 +7122,7 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   align-items: center;
 }
 
-.c52 {
+.c53 {
   min-width: 0;
   box-sizing: border-box;
   margin: auto;
@@ -5703,9 +7132,10 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
+  max-width: 560px;
+  width: 100%;
+  min-width: 300px;
+  max-height: 480px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -5863,7 +7293,7 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   padding-right: 8px;
   margin-right: 8px;
   display: inline-block;
-  min-width: 160px;
+  min-width: 240px;
   text-align: left;
 }
 
@@ -5892,12 +7322,11 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 280px;
   width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
   text-align: left;
 }
 
@@ -5928,7 +7357,7 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   justify-content: space-between;
 }
 
-.c49 {
+.c50 {
   min-width: 0;
   box-sizing: border-box;
   padding-left: 24px;
@@ -5942,13 +7371,107 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   text-align: right;
 }
 
+.c6 {
+  min-width: 0;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  border-width: 1px;
+  padding: 16px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  background-color: #D2F5ED;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: auto;
+  overflow: hidden;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c7 {
+  min-width: 0;
+  box-sizing: border-box;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c9 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-width: 0.1875rem;
+  border-radius: 8px;
+  border-style: solid;
+  border-color: #007056;
+  background-color: #007056;
+  color: #D2F5ED;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 48px;
+  height: 48px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.c13 {
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 100px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: #007056;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+}
+
 .c10 {
   font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
   font-weight: 700;
   font-size: 1.5rem;
 }
 
-.c53 {
+.c54 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -5967,11 +7490,11 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   border-radius: 4px;
 }
 
-.c53:hover {
+.c54:hover {
   opacity: 0.8;
 }
 
-.c54 {
+.c55 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -5990,16 +7513,16 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   border-radius: 4px;
 }
 
-.c54:hover {
+.c55:hover {
   opacity: 0.8;
 }
 
-.c1 {
+.c2 {
   width: 24;
   height: 24;
 }
 
-.c11 {
+.c49 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -6007,32 +7530,12 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   margin: 0;
 }
 
-.c50 {
+.c51 {
   color: #5E26FF;
   font-size: 2rem;
   font-weight: 700;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c13 {
-  color: #262626;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-right: 8px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c18 {
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  text-align: center;
   margin: 0;
 }
 
@@ -6046,6 +7549,42 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
 
 .c47 {
   color: #666666;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  width: 100%;
+}
+
+.c11 {
+  color: #007056;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  margin-left: 8px;
+}
+
+.c14 {
+  color: #007056;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c16 {
+  color: #262626;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  font-family: RT-Alias-Grotesk;
+}
+
+.c18 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -6189,6 +7728,8 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   font-size: 2rem;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 16px;
+  padding-right: 16px;
   height: 100%;
   display: inline-block;
   width: 100%;
@@ -6260,7 +7801,7 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   margin: 0;
 }
 
-.c2 {
+.c3 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6278,39 +7819,7 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  border-color: silver;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c8 {
-  margin-right: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c0 {
+.c1 {
   outline: 0;
   border: 0;
   background: transparent;
@@ -6318,1949 +7827,546 @@ exports[`Send Flow snapshots it renders step 4 correctly 1`] = `
   transition: 0.24s ease-in-out;
   cursor: pointer;
   display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
+  margin-left: auto;
+  justify-self: flex-end;
+  position: relative;
 }
 
-.c0:hover {
+.c1:hover {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c51 {
+.c17 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  font-size: inherit;
+}
+
+.c52 {
   word-wrap: break-word;
 }
 
-@media screen and (min-width:40em) {
-  .c41 {
-    min-width: 160px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c41 {
-    min-width: 240px;
-  }
-}
-
 <div>
-  <button
+  <div
     class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
+    display="flex"
+    width="100%"
   >
-    <svg
+    <button
       class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      display="inline-block"
+      role="button"
+      type="button"
     >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
+      <svg
+        class="c2"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
+          fill="#5E26FF"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <form
       class="c3"
-      display="flex"
-      width="13"
     >
       <div
         class="c4"
+        display="flex"
+        width="100%"
       >
         <div
           class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
         >
-          <ul
+          <div
             class="c6"
             display="flex"
-            width="100%"
+            overflow="hidden"
+            width="auto"
           >
             <div
               class="c7"
               display="flex"
+              width="auto"
             >
-              <li
+              <div
                 class="c8"
                 display="flex"
               >
                 <div
                   class="c9"
-                  color="#000"
+                  color="card.confirmation.background"
                   display="flex"
                   size="6"
                 >
                   <h3
                     class="c10"
                   >
-                    Sf
+                    Cf
                   </h3>
                 </div>
-              </li>
-              <li
-                class=""
-              >
-                <h2
-                  class="c11"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="4"
-                  font-weight="400"
-                >
-                  Sending Filecoin
-                </h2>
-              </li>
-            </div>
-            <li
-              class=""
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
                 <p
-                  class="c13"
-                  color="core.nearblack"
+                  class="c11"
+                  color="card.confirmation.foreground"
                   font-family="RT-Alias-Grotesk"
                   font-size="2"
                   font-weight="400"
                 >
-                  Step 
-                  4
+                  Confirmation
                 </p>
+              </div>
+              <div
+                class="c12"
+                display="flex"
+              >
                 <div
-                  class="c14"
+                  class="c13"
                   display="flex"
                 >
+                  <p
+                    class="c14"
+                    color="card.confirmation.foreground"
+                    font-family="RT-Alias-Grotesk"
+                    font-size="2"
+                    font-weight="400"
+                  >
+                    Step 
+                    5
+                  </p>
                   <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    class="c12"
+                    display="flex"
+                  >
+                    <div
+                      class="c15"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    class="c12"
+                    display="flex"
+                  >
+                    <div
+                      class="c15"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    class="c12"
+                    display="flex"
+                  >
+                    <div
+                      class="c15"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
-                    class="c15"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c14"
-                  display="flex"
-                >
+                    class="c12"
+                    display="flex"
+                  >
+                    <div
+                      class="c15"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                   <div
-                    class="c16"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
+                    class="c12"
+                    display="flex"
+                  >
+                    <div
+                      class="c15"
+                      display="inline-block"
+                      height="2"
+                      width="2"
+                    />
+                  </div>
                 </div>
               </div>
-            </li>
-          </ul>
-          <div
-            class="c17"
-          >
+            </div>
+            <p
+              class="c16"
+              color="core.nearblack"
+              font-family="RT-Alias-Grotesk"
+              font-size="2"
+              font-weight="400"
+            >
+              To complete the transaction, please review the
+               
+              <span
+                class="c17"
+                font-size="inherit"
+              >
+                recipient
+              </span>
+               and
+               
+              <span
+                class="c17"
+                font-size="inherit"
+              >
+                amount
+              </span>
+               and click ”Send” at the bottom of the page.
+            </p>
             <p
               class="c18"
               font-family="RT-Alias-Grotesk"
               font-size="2"
               font-weight="400"
             >
-              Please review the transaction details.
+              <span
+                class="c17"
+                font-size="inherit"
+              >
+                Remember:
+              </span>
+               Transactions are
+               
+              <span
+                class="c17"
+                font-size="inherit"
+              >
+                final once sent.
+              </span>
             </p>
           </div>
-        </div>
-        <div
-          class="c19"
-        >
           <div
-            class="c20"
-            color="core.white"
-            width="100%"
+            class="c19"
           >
             <div
-              class="c21"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c22"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c10"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c23"
-                  display="flex"
-                >
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    From
-                  </p>
-                  <p
-                    class="c24"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    t1z225 ... 6z6wgi
-                  </p>
-                </div>
-              </div>
-              <div
-                class="c23"
-                display="flex"
-              >
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c24"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c25"
-            width="100%"
-          >
-            <div
-              class="c26"
-            >
-              <div
-                class="c14"
-                display="flex"
-              >
-                <div
-                  class="c27"
-                  display="flex"
-                >
-                  <h4
-                    class="c28"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Recipient
-                  </h4>
-                </div>
-                <div
-                  class="c29"
-                  display="flex"
-                >
-                  <input
-                    class="c30"
-                    disabled=""
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
-                    width="100%"
-                  />
-                  
-                </div>
-              </div>
-            </div>
-            
-          </div>
-          <div
-            class="c4"
-          >
-            <div
-              class="c31"
+              class="c20"
+              color="core.white"
               width="100%"
             >
               <div
-                class="c32"
-                display="flex"
-                name="amount"
-              >
-                <div
-                  class="c33"
-                  color="input.border"
-                  display="flex"
-                  width="100%"
-                >
-                  <h4
-                    class="c28"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Amount
-                  </h4>
-                </div>
-                <div
-                  class="c34"
-                  display="inline-block"
-                  width="100%"
-                >
-                  <div
-                    class="c35"
-                    display="flex"
-                    height="80px"
-                    width="100%"
-                  >
-                    <input
-                      class="c36"
-                      disabled=""
-                      display="inline-block"
-                      font-size="5"
-                      height="100%"
-                      name="amount"
-                      placeholder="0"
-                      step="0.000000000000000001"
-                      type="number"
-                      value="0.01"
-                      width="100%"
-                    />
-                    <div
-                      class="c37"
-                      color="core.primary"
-                      disabled=""
-                      display="flex"
-                      font-size="3"
-                      height="100%"
-                    >
-                      FIL
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="c31"
-              width="100%"
-            >
-              <div
-                class="c38"
+                class="c21"
                 display="flex"
               >
                 <div
-                  class="c39"
+                  class="c8"
                   display="flex"
                 >
                   <div
-                    class="c26"
-                    name="tx-fee"
+                    class="c22"
+                    color="white"
+                    display="flex"
+                    size="6"
                   >
-                    <div
-                      class="c40"
-                      display="flex"
+                    <h3
+                      class="c10"
                     >
-                      <div
-                        class="c41"
-                        display="inline-block"
-                      >
-                        <h4
-                          class="c42"
-                          font-family="RT-Alias-Grotesk"
-                          font-size="2"
-                          font-weight="400"
-                        >
-                          Transaction fee
-                        </h4>
-                      </div>
-                      <div
-                        class="c43"
-                        color="background.screen"
-                        display="flex"
-                        width="100%"
-                      >
-                        <input
-                          class="c44"
-                          display="inline-block"
-                          height="6"
-                          type="number"
-                          value="1000000"
-                          width="100%"
-                        />
-                        <div
-                          class="c45"
-                          color="core.primary"
-                          display="flex"
-                          font-size="3"
-                          height="6"
-                        >
-                          aFil
-                        </div>
-                      </div>
-                    </div>
+                      Ms
+                    </h3>
                   </div>
                   <div
-                    class="c46"
+                    class="c23"
                     display="flex"
-                    width="100%"
                   >
                     <p
-                      class="c47"
-                      color="core.darkgray"
+                      class="c24"
                       font-family="RT-Alias-Grotesk"
                       font-size="2"
                       font-weight="400"
                     >
-                      *You will not pay more than 
-                      0.000000000001
-                       FIL for this transaction.
+                      From
+                    </p>
+                    <p
+                      class="c24"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      t1z225 ... 6z6wgi
                     </p>
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c48"
-            display="flex"
-          >
-            <h2
-              class="c11"
-              font-family="RT-Alias-Grotesk"
-              font-size="4"
-              font-weight="400"
-            >
-              Total
-            </h2>
-            <div
-              class="c49"
-              display="flex"
-            >
-              <h2
-                class="c50 c51"
-                color="core.primary"
-                font-family="RT-Alias-Grotesk"
-                font-size="5"
-                font-weight="700"
-              >
-                0.01
-                 FIL
-              </h2>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c52"
-        display="flex"
-        width="13"
-      >
-        <button
-          class="c53"
-          font-size="3"
-          height="6"
-          type="button"
-        >
-          Back
-        </button>
-        <button
-          class="c54"
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Next
-        </button>
-      </div>
-    </div>
-  </form>
-</div>
-`;
-
-exports[`Send Flow snapshots it renders step 5 correctly 1`] = `
-.c3 {
-  min-width: 0;
-  box-sizing: border-box;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  min-width: 0;
-  box-sizing: border-box;
-}
-
-.c7 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c11 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c18 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-radius: 16px;
-  box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
-}
-
-.c19 {
-  min-width: 0;
-  box-sizing: border-box;
-  border: 0;
-  border-top-right-radius: 8px;
-  border-top-left-radius: 8px;
-  padding: 16px;
-  background-color: #5E26FF;
-  color: #ffffff;
-  width: 100%;
-}
-
-.c20 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c21 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-width: 0.1875rem;
-  border-radius: 8px;
-  border-style: solid;
-  margin-right: 16px;
-  color: white;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 48px;
-  height: 48px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c22 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-}
-
-.c24 {
-  min-width: 0;
-  box-sizing: border-box;
-  border: 0;
-  padding: 16px;
-  background-color: #EFF3FD;
-  width: 100%;
-}
-
-.c26 {
-  min-width: 0;
-  box-sizing: border-box;
-  margin-right: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 48px;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c28 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c52 {
-  min-width: 0;
-  box-sizing: border-box;
-  margin: auto;
-  margin-top: 16px;
-  margin-bottom: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-width: 640px;
-  width: 560px;
-  min-width: 480px;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c31 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  border-color: #999999;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-height: 120px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c32 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-radius: 4px;
-  padding-left: 8px;
-  padding-right: 8px;
-  margin-right: 8px;
-  color: #999999;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  max-width: 240px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  text-align: center;
-}
-
-.c33 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: inline-block;
-  width: 100%;
-}
-
-.c34 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  border-bottom: 1px solid;
-  border-color: #EFF3FD;
-  border-top-left-radius: 4px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 80px;
-  width: 100%;
-}
-
-.c30 {
-  min-width: 0;
-  box-sizing: border-box;
-  border: 0;
-  padding-left: 16px;
-  padding-right: 16px;
-  background-color: #EFF3FD;
-  width: 100%;
-}
-
-.c37 {
-  min-width: 0;
-  box-sizing: border-box;
-  background-color: #EFF3FD;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c38 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-width: 560px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c39 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c40 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 8px;
-  padding-right: 8px;
-  margin-right: 8px;
-  display: inline-block;
-  min-width: 160px;
-  text-align: left;
-}
-
-.c42 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  border-bottom: 1px solid;
-  border-top: 1px solid;
-  color: #EFF3FD;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c45 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-width: 280px;
-  width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  text-align: left;
-}
-
-.c47 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  padding-top: 48px;
-  padding-bottom: 32px;
-  padding-left: 16px;
-  padding-right: 16px;
-  background-color: #EFF3FD;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c49 {
-  min-width: 0;
-  box-sizing: border-box;
-  padding-left: 24px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  text-align: right;
-}
-
-.c5 {
-  min-width: 0;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  border-width: 1px;
-  padding: 16px;
-  margin-top: 8px;
-  margin-bottom: 8px;
-  background-color: #D2F5ED;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: auto;
-  overflow: hidden;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c6 {
-  min-width: 0;
-  box-sizing: border-box;
-  border: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c8 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-width: 0.1875rem;
-  border-radius: 8px;
-  border-style: solid;
-  border-color: #007056;
-  background-color: #007056;
-  color: #D2F5ED;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 48px;
-  height: 48px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  text-align: center;
-}
-
-.c12 {
-  min-width: 0;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c14 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-radius: 100px;
-  margin-left: 4px;
-  margin-right: 4px;
-  background-color: #007056;
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-}
-
-.c9 {
-  font-family: "RT-Alias-Medium","system-ui","Segoe UI","Roboto",Helvetica;
-  font-weight: 700;
-  font-size: 1.5rem;
-}
-
-.c53 {
-  cursor: pointer;
-  border: 1px solid #262626;
-  background-color: transparent;
-  border-color: #262626;
-  color: #262626;
-  font-size: 1.125rem;
-  -webkit-transition: 0.18s ease-in-out;
-  transition: 0.18s ease-in-out;
-  border-radius: 4px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 16px;
-  padding-right: 16px;
-  height: 48px;
-  border-width: 1px;
-  border-radius: 4px;
-}
-
-.c53:hover {
-  opacity: 0.8;
-}
-
-.c54 {
-  cursor: pointer;
-  border: 1px solid #1AD08F;
-  background-color: #1AD08F;
-  border-color: #1AD08F;
-  color: #08442F;
-  font-size: 1.125rem;
-  -webkit-transition: 0.18s ease-in-out;
-  transition: 0.18s ease-in-out;
-  border-radius: 4px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 16px;
-  padding-right: 16px;
-  height: 48px;
-  border-width: 1px;
-  border-radius: 4px;
-}
-
-.c54:hover {
-  opacity: 0.8;
-}
-
-.c1 {
-  width: 24;
-  height: 24;
-}
-
-.c48 {
-  font-size: 1.5rem;
-  font-weight: 400;
-  line-height: 1.2;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c50 {
-  color: #5E26FF;
-  font-size: 2rem;
-  font-weight: 700;
-  line-height: 1.2;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c23 {
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c46 {
-  color: #666666;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-}
-
-.c10 {
-  color: #007056;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-left: 8px;
-}
-
-.c13 {
-  color: #007056;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin-right: 8px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c15 {
-  color: #262626;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-}
-
-.c17 {
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-}
-
-.c27 {
-  color: #262626;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c41 {
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c29 {
-  min-width: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  padding-left: 8px;
-  padding-right: 8px;
-  border-radius: 1px;
-  -webkit-transition: 0.2s ease-in-out;
-  transition: 0.2s ease-in-out;
-  font-size: 1.125rem;
-  text-align: left;
-  cursor: text;
-  background: #bacbf7;
-  padding-left: 16px;
-  padding-right: 16px;
-  display: inline-block;
-  height: 48px;
-  width: 100%;
-  border-radius: 4px;
-  border: 0;
-  border-color: #999999;
-}
-
-.c29:hover {
-  background: #bacbf7;
-  cursor: initial;
-}
-
-.c29:focus {
-  box-shadow: 0;
-  outline: 0;
-  background: #bacbf7;
-}
-
-.c25 {
-  display: inline-block;
-  width: 100%;
-  border-radius: 1px;
-}
-
-.c36 {
-  min-width: 0;
-  box-sizing: border-box;
-  top: 0px;
-  left: 0px;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #bacbf7;
-}
-
-.c44 {
-  min-width: 0;
-  box-sizing: border-box;
-  top: 0px;
-  left: 0px;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: #5E26FF;
-  height: 48px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  min-width: 64px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  text-align: center;
-  position: relative;
-  background: #d1ddfa;
-}
-
-.c35 {
-  min-width: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  padding-left: 8px;
-  padding-right: 8px;
-  border-radius: 1px;
-  -webkit-transition: 0.2s ease-in-out;
-  transition: 0.2s ease-in-out;
-  font-size: 1.125rem;
-  text-align: left;
-  cursor: text;
-  background: #bacbf7;
-  font-size: 2rem;
-  margin-top: 0;
-  margin-bottom: 0;
-  height: 100%;
-  display: inline-block;
-  width: 100%;
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
-  border: 0;
-  border-color: #999999;
-  -moz-appearance: textfield;
-}
-
-.c35:hover {
-  background: #bacbf7;
-  cursor: initial;
-}
-
-.c35:focus {
-  box-shadow: 0;
-  outline: 0;
-  background: #bacbf7;
-}
-
-.c35::-webkit-outer-spin-button,
-.c35::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.c43 {
-  min-width: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  padding-left: 8px;
-  padding-right: 8px;
-  border-radius: 1px;
-  -webkit-transition: 0.2s ease-in-out;
-  transition: 0.2s ease-in-out;
-  font-size: 1.125rem;
-  text-align: left;
-  cursor: text;
-  background: #d1ddfa;
-  padding-left: 16px;
-  padding-right: 16px;
-  display: inline-block;
-  height: 48px;
-  width: 100%;
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
-  border: 0;
-  border-color: #999999;
-  -moz-appearance: textfield;
-}
-
-.c43:hover {
-  background: #bacbf7;
-  cursor: text;
-}
-
-.c43:focus {
-  box-shadow: 0;
-  outline: 0;
-  background: #bacbf7;
-}
-
-.c43::-webkit-outer-spin-button,
-.c43::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.c2 {
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 {
-  outline: 0;
-  border: 0;
-  background: transparent;
-  -webkit-transition: 0.24s ease-in-out;
-  transition: 0.24s ease-in-out;
-  cursor: pointer;
-  display: inline-block;
-  position: fixed;
-  top: 16px;
-  right: 16px;
-}
-
-.c0:hover {
-  -webkit-transform: scale(1.25);
-  -ms-transform: scale(1.25);
-  transform: scale(1.25);
-}
-
-.c16 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  font-size: inherit;
-}
-
-.c51 {
-  word-wrap: break-word;
-}
-
-@media screen and (min-width:40em) {
-  .c40 {
-    min-width: 160px;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c40 {
-    min-width: 240px;
-  }
-}
-
-<div>
-  <button
-    class="c0"
-    display="inline-block"
-    role="button"
-    type="button"
-  >
-    <svg
-      class="c1"
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M19.7333 4.2669C19.3776 3.91103 18.801 3.91103 18.4453 4.2669L11.9994 10.7166L5.55552 4.26885C5.19986 3.91299 4.62323 3.91299 4.26757 4.26885C3.91191 4.62472 3.91191 5.20169 4.26757 5.55756L10.7115 12.0053L4.27793 18.4426C3.92228 18.7985 3.92228 19.3755 4.27793 19.7313C4.63359 20.0872 5.21022 20.0872 5.56587 19.7313L11.9994 13.294L18.435 19.7333C18.7906 20.0892 19.3672 20.0892 19.7229 19.7333C20.0786 19.3774 20.0786 18.8005 19.7229 18.4446L13.2874 12.0053L19.7333 5.5556C20.0889 5.19974 20.0889 4.62276 19.7333 4.2669Z"
-        fill="#5E26FF"
-        fill-rule="evenodd"
-      />
-    </svg>
-  </button>
-  <form
-    class="c2"
-  >
-    <div
-      class="c3"
-      display="flex"
-      width="13"
-    >
-      <div
-        class="c4"
-      >
-        <div
-          class="c5"
-          display="flex"
-          overflow="hidden"
-          width="auto"
-        >
-          <div
-            class="c6"
-            display="flex"
-            width="auto"
-          >
-            <div
-              class="c7"
-              display="flex"
-            >
-              <div
-                class="c8"
-                color="card.confirmation.background"
-                display="flex"
-                size="6"
-              >
-                <h3
-                  class="c9"
-                >
-                  Cf
-                </h3>
-              </div>
-              <p
-                class="c10"
-                color="card.confirmation.foreground"
-                font-family="RT-Alias-Grotesk"
-                font-size="2"
-                font-weight="400"
-              >
-                Confirmation
-              </p>
-            </div>
-            <div
-              class="c11"
-              display="flex"
-            >
-              <div
-                class="c12"
-                display="flex"
-              >
-                <p
-                  class="c13"
-                  color="card.confirmation.foreground"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Step 
-                  5
-                </p>
                 <div
-                  class="c11"
-                  display="flex"
-                >
-                  <div
-                    class="c14"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c11"
-                  display="flex"
-                >
-                  <div
-                    class="c14"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c11"
-                  display="flex"
-                >
-                  <div
-                    class="c14"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c11"
-                  display="flex"
-                >
-                  <div
-                    class="c14"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-                <div
-                  class="c11"
-                  display="flex"
-                >
-                  <div
-                    class="c14"
-                    display="inline-block"
-                    height="2"
-                    width="2"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <p
-            class="c15"
-            color="core.nearblack"
-            font-family="RT-Alias-Grotesk"
-            font-size="2"
-            font-weight="400"
-          >
-            To complete the transaction, please review the
-             
-            <span
-              class="c16"
-              font-size="inherit"
-            >
-              recipient
-            </span>
-             and
-             
-            <span
-              class="c16"
-              font-size="inherit"
-            >
-              amount
-            </span>
-             and click ”Send” at the bottom of the page.
-          </p>
-          <p
-            class="c17"
-            font-family="RT-Alias-Grotesk"
-            font-size="2"
-            font-weight="400"
-          >
-            <span
-              class="c16"
-              font-size="inherit"
-            >
-              Remember:
-            </span>
-             Transactions are
-             
-            <span
-              class="c16"
-              font-size="inherit"
-            >
-              final once sent.
-            </span>
-          </p>
-        </div>
-        <div
-          class="c18"
-        >
-          <div
-            class="c19"
-            color="core.white"
-            width="100%"
-          >
-            <div
-              class="c20"
-              display="flex"
-            >
-              <div
-                class="c7"
-                display="flex"
-              >
-                <div
-                  class="c21"
-                  color="white"
-                  display="flex"
-                  size="6"
-                >
-                  <h3
-                    class="c9"
-                  >
-                    Ms
-                  </h3>
-                </div>
-                <div
-                  class="c22"
+                  class="c23"
                   display="flex"
                 >
                   <p
-                    class="c23"
+                    class="c24"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    From
+                    Balance
                   </p>
                   <p
-                    class="c23"
+                    class="c24"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
                     font-weight="400"
                   >
-                    t1z225 ... 6z6wgi
+                    1
+                     FIL
                   </p>
                 </div>
               </div>
-              <div
-                class="c22"
-                display="flex"
-              >
-                <p
-                  class="c23"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  Balance
-                </p>
-                <p
-                  class="c23"
-                  font-family="RT-Alias-Grotesk"
-                  font-size="2"
-                  font-weight="400"
-                >
-                  1
-                   FIL
-                </p>
-              </div>
             </div>
-          </div>
-          <div
-            class="c24"
-            width="100%"
-          >
             <div
               class="c25"
-            >
-              <div
-                class="c11"
-                display="flex"
-              >
-                <div
-                  class="c26"
-                  display="flex"
-                >
-                  <h4
-                    class="c27"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Recipient
-                  </h4>
-                </div>
-                <div
-                  class="c28"
-                  display="flex"
-                >
-                  <input
-                    class="c29"
-                    disabled=""
-                    display="inline-block"
-                    height="6"
-                    placeholder="f1..."
-                    value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
-                    width="100%"
-                  />
-                  
-                </div>
-              </div>
-            </div>
-            
-          </div>
-          <div
-            class="c4"
-          >
-            <div
-              class="c30"
               width="100%"
             >
               <div
+                class="c26"
+              >
+                <div
+                  class="c12"
+                  display="flex"
+                >
+                  <div
+                    class="c27"
+                    display="flex"
+                  >
+                    <h4
+                      class="c28"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
+                    >
+                      Recipient
+                    </h4>
+                  </div>
+                  <div
+                    class="c29"
+                    display="flex"
+                  >
+                    <input
+                      class="c30"
+                      disabled=""
+                      display="inline-block"
+                      height="6"
+                      placeholder="f1..."
+                      value="t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
+                      width="100%"
+                    />
+                    
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              class="c5"
+            >
+              <div
                 class="c31"
-                display="flex"
-                name="amount"
+                width="100%"
               >
                 <div
                   class="c32"
-                  color="input.border"
                   display="flex"
-                  width="100%"
-                >
-                  <h4
-                    class="c27"
-                    color="core.nearblack"
-                    font-family="RT-Alias-Grotesk"
-                    font-size="2"
-                    font-weight="400"
-                  >
-                    Amount
-                  </h4>
-                </div>
-                <div
-                  class="c33"
-                  display="inline-block"
-                  width="100%"
+                  name="amount"
                 >
                   <div
-                    class="c34"
+                    class="c33"
+                    color="input.border"
                     display="flex"
-                    height="80px"
                     width="100%"
                   >
-                    <input
-                      class="c35"
-                      disabled=""
-                      display="inline-block"
-                      font-size="5"
-                      height="100%"
-                      name="amount"
-                      placeholder="0"
-                      step="0.000000000000000001"
-                      type="number"
-                      value="0.01"
-                      width="100%"
-                    />
-                    <div
-                      class="c36"
-                      color="core.primary"
-                      disabled=""
-                      display="flex"
-                      font-size="3"
-                      height="100%"
+                    <h4
+                      class="c28"
+                      color="core.nearblack"
+                      font-family="RT-Alias-Grotesk"
+                      font-size="2"
+                      font-weight="400"
                     >
-                      FIL
+                      Amount
+                    </h4>
+                  </div>
+                  <div
+                    class="c34"
+                    display="inline-block"
+                    width="100%"
+                  >
+                    <div
+                      class="c35"
+                      display="flex"
+                      height="80px"
+                      width="100%"
+                    >
+                      <input
+                        class="c36"
+                        disabled=""
+                        display="inline-block"
+                        font-size="5"
+                        height="100%"
+                        name="amount"
+                        placeholder="0"
+                        step="0.000000000000000001"
+                        type="number"
+                        value="0.01"
+                        width="100%"
+                      />
+                      <div
+                        class="c37"
+                        color="core.primary"
+                        disabled=""
+                        display="flex"
+                        font-size="3"
+                        height="100%"
+                      >
+                        FIL
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="c30"
-              width="100%"
-            >
               <div
-                class="c37"
-                display="flex"
+                class="c31"
+                width="100%"
               >
                 <div
                   class="c38"
                   display="flex"
                 >
                   <div
-                    class="c25"
-                    name="tx-fee"
+                    class="c39"
+                    display="flex"
                   >
                     <div
-                      class="c39"
-                      display="flex"
+                      class="c26"
+                      name="tx-fee"
                     >
                       <div
                         class="c40"
-                        display="inline-block"
-                      >
-                        <h4
-                          class="c41"
-                          font-family="RT-Alias-Grotesk"
-                          font-size="2"
-                          font-weight="400"
-                        >
-                          Transaction fee
-                        </h4>
-                      </div>
-                      <div
-                        class="c42"
-                        color="background.screen"
                         display="flex"
-                        width="100%"
                       >
-                        <input
-                          class="c43"
-                          display="inline-block"
-                          height="6"
-                          type="number"
-                          value="1000000"
-                          width="100%"
-                        />
                         <div
-                          class="c44"
-                          color="core.primary"
-                          display="flex"
-                          font-size="3"
-                          height="6"
+                          class="c41"
+                          display="inline-block"
                         >
-                          aFil
+                          <h4
+                            class="c42"
+                            font-family="RT-Alias-Grotesk"
+                            font-size="2"
+                            font-weight="400"
+                          >
+                            Transaction fee
+                          </h4>
+                        </div>
+                        <div
+                          class="c43"
+                          color="background.screen"
+                          display="flex"
+                          width="100%"
+                        >
+                          <input
+                            class="c44"
+                            display="inline-block"
+                            height="6"
+                            type="number"
+                            value="1000000"
+                            width="100%"
+                          />
+                          <div
+                            class="c45"
+                            color="core.primary"
+                            display="flex"
+                            font-size="3"
+                            height="6"
+                          >
+                            aFil
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    class="c45"
-                    display="flex"
-                    width="100%"
-                  >
-                    <p
+                    <div
                       class="c46"
-                      color="core.darkgray"
-                      font-family="RT-Alias-Grotesk"
-                      font-size="2"
-                      font-weight="400"
+                      display="flex"
+                      width="100%"
                     >
-                      *You will not pay more than 
-                      0.000000000001
-                       FIL for this transaction.
-                    </p>
+                      <p
+                        class="c47"
+                        color="core.darkgray"
+                        font-family="RT-Alias-Grotesk"
+                        font-size="2"
+                        font-weight="400"
+                        width="100%"
+                      >
+                        You will not pay more than 
+                        0.000000000001
+                         FIL for this transaction.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="c47"
-            display="flex"
-          >
-            <h2
-              class="c48"
-              font-family="RT-Alias-Grotesk"
-              font-size="4"
-              font-weight="400"
-            >
-              Total
-            </h2>
             <div
-              class="c49"
+              class="c48"
               display="flex"
             >
               <h2
-                class="c50 c51"
-                color="core.primary"
+                class="c49"
                 font-family="RT-Alias-Grotesk"
-                font-size="5"
-                font-weight="700"
+                font-size="4"
+                font-weight="400"
               >
-                0.01
-                 FIL
+                Total
               </h2>
+              <div
+                class="c50"
+                display="flex"
+              >
+                <h2
+                  class="c51 c52"
+                  color="core.primary"
+                  font-family="RT-Alias-Grotesk"
+                  font-size="5"
+                  font-weight="700"
+                >
+                  0.01
+                   FIL
+                </h2>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="c52"
-        display="flex"
-        width="13"
-      >
-        <button
+        <div
           class="c53"
-          font-size="3"
-          height="6"
-          type="button"
+          display="flex"
+          width="100%"
         >
-          Back
-        </button>
-        <button
-          class="c54"
-          font-size="3"
-          height="6"
-          type="submit"
-        >
-          Send
-        </button>
+          <button
+            class="c54"
+            font-size="3"
+            height="6"
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            class="c55"
+            font-size="3"
+            height="6"
+            type="submit"
+          >
+            Send
+          </button>
+        </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>
 `;
 

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -262,7 +262,7 @@ const Send = ({ close }) => {
       <Form onSubmit={onSubmit}>
         <Box
           maxWidth={14}
-          width={13}
+          width='100%'
           minWidth={12}
           display='flex'
           flex='1'
@@ -425,7 +425,7 @@ const Send = ({ close }) => {
             alignItems='flex-end'
             margin='auto'
             maxWidth={14}
-            width={13}
+            width='100%'
             minWidth={12}
             my={3}
           >

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -246,213 +246,216 @@ const Send = ({ close }) => {
 
   return (
     <>
-      <ButtonClose
-        role='button'
-        type='button'
-        position='fixed'
-        top='3'
-        right='3'
-        onClick={() => {
-          setAttemptingTx(false)
-          setUncaughtError('')
-          resetLedgerState()
-          close()
-        }}
-      />
-      <Form onSubmit={onSubmit}>
-        <Box
-          maxWidth={14}
-          width='100%'
-          minWidth={12}
-          display='flex'
-          flex='1'
-          flexDirection='column'
-          justifyContent='space-between'
-        >
-          <Box>
-            {hasError() && (
-              <ErrorCard
-                error={ledgerError() || uncaughtError}
-                reset={() => {
+      <Box display='flex' flexDirection='column' width='100%'>
+        <ButtonClose
+          role='button'
+          type='button'
+          position='relative'
+          justifySelf='flex-end'
+          marginLeft='auto'
+          onClick={() => {
+            setAttemptingTx(false)
+            setUncaughtError('')
+            resetLedgerState()
+            close()
+          }}
+        />
+        <Form onSubmit={onSubmit}>
+          <Box
+            maxWidth={13}
+            width='100%'
+            minWidth={11}
+            display='flex'
+            flex='1'
+            flexDirection='column'
+            justifyContent='flex-start'
+          >
+            <Box>
+              {hasError() && (
+                <ErrorCard
+                  error={ledgerError() || uncaughtError}
+                  reset={() => {
+                    setAttemptingTx(false)
+                    setUncaughtError('')
+                    resetLedgerState()
+                    setStep(step - 1)
+                  }}
+                />
+              )}
+              {!hasError() && attemptingTx && (
+                <ConfirmationCard
+                  walletType={wallet.type}
+                  currentStep={5}
+                  totalSteps={5}
+                  loading={fetchingTxDetails || mPoolPushing}
+                />
+              )}
+              {!hasError() && !attemptingTx && (
+                <>
+                  <Card
+                    display='flex'
+                    flexDirection='column'
+                    justifyContent='space-between'
+                    border='none'
+                    width='auto'
+                    my={2}
+                    backgroundColor='blue.muted700'
+                  >
+                    <StepHeader
+                      title='Sending Filecoin'
+                      currentStep={step}
+                      totalSteps={5}
+                      glyphAcronym='Sf'
+                    />
+                    <Box mt={6} mb={4}>
+                      <HeaderText step={step} walletType={wallet.type} />
+                    </Box>
+                  </Card>
+                </>
+              )}
+              <Box boxShadow={2} borderRadius={4}>
+                <CardHeader address={wallet.address} balance={wallet.balance} />
+
+                <Box width='100%' p={3} border={0} bg='background.screen'>
+                  <Input.Address
+                    label='Recipient'
+                    value={toAddress}
+                    onChange={e => setToAddress(e.target.value)}
+                    error={toAddressError}
+                    disabled={step > 1}
+                    placeholder='f1...'
+                    onFocus={() => {
+                      if (toAddressError) setToAddressError('')
+                    }}
+                  />
+                </Box>
+                <Box>
+                  {step > 1 && (
+                    <Box
+                      width='100%'
+                      px={3}
+                      pb={step === 2 && 3}
+                      border={0}
+                      bg='background.screen'
+                    >
+                      <Input.Funds
+                        name='amount'
+                        label='Amount'
+                        amount={value.toAttoFil()}
+                        onAmountChange={setValue}
+                        balance={wallet.balance}
+                        error={valueError}
+                        setError={setValueError}
+                        disabled={step > 2 && !hasError()}
+                      />
+                    </Box>
+                  )}
+                  {step > 2 && (
+                    <Box
+                      width='100%'
+                      px={3}
+                      pb={step === 3 && 3}
+                      border={0}
+                      bg='background.screen'
+                    >
+                      <CustomizeFee
+                        message={new Message({
+                          to: toAddress,
+                          from: wallet.address,
+                          value: value.toAttoFil(),
+                          nonce: 0,
+                          method: 0,
+                          params: '',
+                          gasFeeCap: gasInfo.gasFeeCap.toAttoFil(),
+                          gasLimit: new BigNumber(
+                            gasInfo.gasLimit.toAttoFil()
+                          ).toNumber(),
+                          gasPremium: gasInfo.gasPremium.toAttoFil()
+                        }).toLotusType()}
+                        gasInfo={gasInfo}
+                        setGasInfo={setGasInfo}
+                        setFrozen={setFrozen}
+                        setError={setGasError}
+                        error={gasError}
+                        feeMustBeLessThanThisAmount={calcMaxAffordableFee()}
+                      />
+                    </Box>
+                  )}
+                </Box>
+                {step > 3 && (
+                  <Box
+                    display='flex'
+                    flexDirection='row'
+                    alignItems='flex-start'
+                    justifyContent='space-between'
+                    pt={6}
+                    pb={5}
+                    px={3}
+                    bg='background.screen'
+                    borderBottomLeftRadius={3}
+                    borderBottomRightRadius={3}
+                  >
+                    <Title fontSize={4} alignSelf='flex-start'>
+                      Total
+                    </Title>
+                    <Box
+                      display='flex'
+                      flexDirection='column'
+                      textAlign='right'
+                      pl={4}
+                    >
+                      <Num
+                        size='l'
+                        css={`
+                          word-wrap: break-word;
+                        `}
+                        color='core.primary'
+                      >
+                        {value.toFil()} FIL
+                      </Num>
+                    </Box>
+                  </Box>
+                )}
+              </Box>
+            </Box>
+            <Box
+              display='flex'
+              flexGrow='1'
+              flexDirection='row'
+              justifyContent='space-between'
+              alignItems='flex-end'
+              margin='auto'
+              maxWidth={13}
+              width='100%'
+              minWidth={11}
+              maxHeight={12}
+              my={3}
+            >
+              <Button
+                title='Back'
+                variant='secondary'
+                onClick={() => {
                   setAttemptingTx(false)
                   setUncaughtError('')
                   resetLedgerState()
-                  setStep(step - 1)
+                  if (step === 1) {
+                    close()
+                  } else {
+                    setStep(step - 1)
+                  }
                 }}
+                disabled={isBackBtnDisabled()}
               />
-            )}
-            {!hasError() && attemptingTx && (
-              <ConfirmationCard
-                walletType={wallet.type}
-                currentStep={5}
-                totalSteps={5}
-                loading={fetchingTxDetails || mPoolPushing}
+              <Button
+                variant='primary'
+                title={submitBtnText()}
+                disabled={isSubmitBtnDisabled()}
+                type='submit'
               />
-            )}
-            {!hasError() && !attemptingTx && (
-              <>
-                <Card
-                  display='flex'
-                  flexDirection='column'
-                  justifyContent='space-between'
-                  border='none'
-                  width='auto'
-                  my={2}
-                  backgroundColor='blue.muted700'
-                >
-                  <StepHeader
-                    title='Sending Filecoin'
-                    currentStep={step}
-                    totalSteps={5}
-                    glyphAcronym='Sf'
-                  />
-                  <Box mt={6} mb={4}>
-                    <HeaderText step={step} walletType={wallet.type} />
-                  </Box>
-                </Card>
-              </>
-            )}
-            <Box boxShadow={2} borderRadius={4}>
-              <CardHeader address={wallet.address} balance={wallet.balance} />
-
-              <Box width='100%' p={3} border={0} bg='background.screen'>
-                <Input.Address
-                  label='Recipient'
-                  value={toAddress}
-                  onChange={e => setToAddress(e.target.value)}
-                  error={toAddressError}
-                  disabled={step > 1}
-                  placeholder='f1...'
-                  onFocus={() => {
-                    if (toAddressError) setToAddressError('')
-                  }}
-                />
-              </Box>
-              <Box>
-                {step > 1 && (
-                  <Box
-                    width='100%'
-                    px={3}
-                    pb={step === 2 && 3}
-                    border={0}
-                    bg='background.screen'
-                  >
-                    <Input.Funds
-                      name='amount'
-                      label='Amount'
-                      amount={value.toAttoFil()}
-                      onAmountChange={setValue}
-                      balance={wallet.balance}
-                      error={valueError}
-                      setError={setValueError}
-                      disabled={step > 2 && !hasError()}
-                    />
-                  </Box>
-                )}
-                {step > 2 && (
-                  <Box
-                    width='100%'
-                    px={3}
-                    pb={step === 3 && 3}
-                    border={0}
-                    bg='background.screen'
-                  >
-                    <CustomizeFee
-                      message={new Message({
-                        to: toAddress,
-                        from: wallet.address,
-                        value: value.toAttoFil(),
-                        nonce: 0,
-                        method: 0,
-                        params: '',
-                        gasFeeCap: gasInfo.gasFeeCap.toAttoFil(),
-                        gasLimit: new BigNumber(
-                          gasInfo.gasLimit.toAttoFil()
-                        ).toNumber(),
-                        gasPremium: gasInfo.gasPremium.toAttoFil()
-                      }).toLotusType()}
-                      gasInfo={gasInfo}
-                      setGasInfo={setGasInfo}
-                      setFrozen={setFrozen}
-                      setError={setGasError}
-                      error={gasError}
-                      feeMustBeLessThanThisAmount={calcMaxAffordableFee()}
-                    />
-                  </Box>
-                )}
-              </Box>
-              {step > 3 && (
-                <Box
-                  display='flex'
-                  flexDirection='row'
-                  alignItems='flex-start'
-                  justifyContent='space-between'
-                  pt={6}
-                  pb={5}
-                  px={3}
-                  bg='background.screen'
-                  borderBottomLeftRadius={3}
-                  borderBottomRightRadius={3}
-                >
-                  <Title fontSize={4} alignSelf='flex-start'>
-                    Total
-                  </Title>
-                  <Box
-                    display='flex'
-                    flexDirection='column'
-                    textAlign='right'
-                    pl={4}
-                  >
-                    <Num
-                      size='l'
-                      css={`
-                        word-wrap: break-word;
-                      `}
-                      color='core.primary'
-                    >
-                      {value.toFil()} FIL
-                    </Num>
-                  </Box>
-                </Box>
-              )}
             </Box>
           </Box>
-          <Box
-            display='flex'
-            flexGrow='1'
-            flexDirection='row'
-            justifyContent='space-between'
-            alignItems='flex-end'
-            margin='auto'
-            maxWidth={14}
-            width='100%'
-            minWidth={12}
-            my={3}
-          >
-            <Button
-              title='Back'
-              variant='secondary'
-              onClick={() => {
-                setAttemptingTx(false)
-                setUncaughtError('')
-                resetLedgerState()
-                if (step === 1) {
-                  close()
-                } else {
-                  setStep(step - 1)
-                }
-              }}
-              disabled={isBackBtnDisabled()}
-            />
-            <Button
-              variant='primary'
-              title={submitBtnText()}
-              disabled={isSubmitBtnDisabled()}
-              type='submit'
-            />
-          </Box>
-        </Box>
-      </Form>
+        </Form>
+      </Box>
     </>
   )
 }

--- a/components/Wallet/Send.js/index.jsx
+++ b/components/Wallet/Send.js/index.jsx
@@ -250,7 +250,6 @@ const Send = ({ close }) => {
         <ButtonClose
           role='button'
           type='button'
-          position='relative'
           justifySelf='flex-end'
           marginLeft='auto'
           onClick={() => {


### PR DESCRIPTION
# Changes
1. Resolves #649 
1. Changes `ButtonClose` from `fixed` to `relative` position to avoid overlap issues
1. Removes explicit  `width` declarations 
1. Increasing `padding` of `Funds` input to match `Numbers` input
1. Removed responsive `minWidth` declaration in `Numbers` input that was affecting its styling at smaller viewports
1. Transaction Fee text now spans the full width of its container
1. Updated `Withdraw` flow styling
1. Updated `ChangeOwner` flow styling to match `Send` and `Withdraw` flows
1. Updated `Warning` card styling

# Reference

## Send Flow
<img width="1119" alt="Screen Shot 2020-10-12 at 1 09 47 PM" src="https://user-images.githubusercontent.com/6787950/95768565-ed3bb500-0c8c-11eb-9e11-bbe6a939ac2b.png">

### Height capped
<img width="613" alt="image" src="https://user-images.githubusercontent.com/6787950/95835176-4569ca00-0d14-11eb-8fe5-151c186421c9.png">


## Withdraw Flow
Showing we cap the height 
<img width="620" alt="image" src="https://user-images.githubusercontent.com/6787950/95834636-96c58980-0d13-11eb-9e1a-ad11f632c804.png">

# Warning Card
(Mini step towards restyling these)
<img width="584" alt="image" src="https://user-images.githubusercontent.com/6787950/95874005-d22d7b80-0d46-11eb-8e8d-9a2be107cb0c.png">

