### PR TITLE
Improve AccountSummary

### DIFF
--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -1,9 +1,25 @@
 import React from 'react'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
-import { Box, Glyph, CopyAddress, Text, Button, IconLedger } from '../../Shared'
-import truncateAddress from '../../../utils/truncateAddress'
+import {
+  Box,
+  Glyph,
+  CopyAddress,
+  Text,
+  BaseButton,
+  IconLedger,
+  InlineBox
+} from '../../Shared'
+
+const ButtonViewOnLedgerDevice = styled(BaseButton)`
+  &:hover {
+    ${InlineBox} {
+      opacity: 1;
+    }
+  }
+`
 
 const AccountSummary = ({
   msigAddress,
@@ -100,17 +116,25 @@ const AccountSummary = ({
                   />
                 </Box>
               </Box>
-              <Button
-                title='View Address on Ledger Device'
-                variant='secondary'
-                borderColor='silver'
-                background='transparent'
-                color='core.darkgray'
+              <ButtonViewOnLedgerDevice
+                display='flex'
+                alignItems='center'
                 height='40px'
                 ml={2}
                 onClick={showOnDevice}
                 disabled={ledgerBusy}
-              />
+                bg='background.messageHistory'
+                border={0}
+                px={2}
+                pr={3}
+              >
+                <IconLedger size={4} mr={2} />
+                {ledgerBusy ? (
+                  <Text>Look at your Ledger device</Text>
+                ) : (
+                  <Text>View Address</Text>
+                )}
+              </ButtonViewOnLedgerDevice>
             </Box>
           </>
         )}

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -9,17 +9,11 @@ import {
   CopyAddress,
   Text,
   BaseButton,
-  IconLedger,
-  InlineBox
+  Button,
+  IconLedger
 } from '../../Shared'
 
-const ButtonViewOnLedgerDevice = styled(BaseButton)`
-  &:hover {
-    ${InlineBox} {
-      opacity: 1;
-    }
-  }
-`
+const ButtonViewOnLedgerDevice = styled(BaseButton)``
 
 const AccountSummary = ({
   msigAddress,

--- a/components/Shared/AccountCard/__snapshots__/index.test.js.snap
+++ b/components/Shared/AccountCard/__snapshots__/index.test.js.snap
@@ -190,6 +190,8 @@ exports[`AccountCard renders the card 1`] = `
   font-weight: 400;
   line-height: 1;
   font-family: RT-Alias-Grotesk;
+  text-align: left;
+  min-width: 64px;
   margin: 0;
   margin-top: 0;
   margin-left: 4px;
@@ -541,6 +543,8 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   font-weight: 400;
   line-height: 1;
   font-family: RT-Alias-Grotesk;
+  text-align: left;
+  min-width: 64px;
   margin: 0;
   margin-top: 0;
   margin-left: 4px;

--- a/components/Shared/Copy/index.jsx
+++ b/components/Shared/Copy/index.jsx
@@ -57,7 +57,7 @@ export const CopyAddress = forwardRef(({ address, ...props }, ref) => {
         }}
       >
         <StyledIconCopyAccountAddress />
-        <LabelCopy mt={0} ml={1} color={props.color}>
+        <LabelCopy mt={0} ml={1} minWidth={7} color={props.color}>
           {copied ? 'Copied' : 'Copy'}
         </LabelCopy>
       </Copy>

--- a/components/Shared/Copy/index.jsx
+++ b/components/Shared/Copy/index.jsx
@@ -57,7 +57,13 @@ export const CopyAddress = forwardRef(({ address, ...props }, ref) => {
         }}
       >
         <StyledIconCopyAccountAddress />
-        <LabelCopy mt={0} ml={1} minWidth={7} color={props.color}>
+        <LabelCopy
+          mt={0}
+          ml={1}
+          minWidth={7}
+          textAlign='left'
+          color={props.color}
+        >
           {copied ? 'Copied' : 'Copy'}
         </LabelCopy>
       </Copy>

--- a/components/Shared/Link/index.jsx
+++ b/components/Shared/Link/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 
 export const StyledATag = styled.a.attrs(props => ({
   color: 'core.primary',
-  fontSize: 3,
+  fontSize: 2,
   ...props
 }))`
   text-decoration: none;

--- a/components/Wallet/Message/Detail/__snapshots__/index.test.js.snap
+++ b/components/Wallet/Message/Detail/__snapshots__/index.test.js.snap
@@ -601,7 +601,7 @@ exports[`MessageHistory View it renders a final, received, SEND transaction corr
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c43:hover {
@@ -1014,7 +1014,7 @@ exports[`MessageHistory View it renders a final, received, SEND transaction corr
       <a
         class="c43"
         color="core.primary"
-        font-size="3"
+        font-size="2"
         href="https://filfox.info/en/message/rdafdsagdfsa"
         rel="noopener noreferrer"
         target="_blank"
@@ -1635,7 +1635,7 @@ exports[`MessageHistory View it renders a final, sent, SEND transaction correctl
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c43:hover {
@@ -2048,7 +2048,7 @@ exports[`MessageHistory View it renders a final, sent, SEND transaction correctl
       <a
         class="c43"
         color="core.primary"
-        font-size="3"
+        font-size="2"
         href="https://filfox.info/en/message/rdafdsagdfsa"
         rel="noopener noreferrer"
         target="_blank"
@@ -2671,7 +2671,7 @@ exports[`MessageHistory View it renders a pending, send transaction correctly 1`
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c43:hover {
@@ -3104,7 +3104,7 @@ exports[`MessageHistory View it renders a pending, send transaction correctly 1`
       <a
         class="c43"
         color="core.primary"
-        font-size="3"
+        font-size="2"
         href="https://filfox.info/en/message/rdafdsagdfsa"
         rel="noopener noreferrer"
         target="_blank"

--- a/components/Wallet/Message/__snapshots__/index.test.js.snap
+++ b/components/Wallet/Message/__snapshots__/index.test.js.snap
@@ -2593,7 +2593,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
   transition: 0.18s ease-in-out;
   border-bottom: 2px solid #5E26FF00;
   color: #5E26FF;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 
 .c43:hover {
@@ -3014,7 +3014,7 @@ exports[`MessageHistory View it renders the message detail view after clicking o
       <a
         class="c43"
         color="core.primary"
-        font-size="3"
+        font-size="2"
         href="https://filfox.info/en/message/bafy2bzacedchco2ff4almriyyfsnxae2fv6xosyffy5s77y2ebqjslt4dovd2"
         rel="noopener noreferrer"
         target="_blank"

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -403,6 +403,8 @@ exports[`WalletView it renders correctly 1`] = `
   font-weight: 400;
   line-height: 1;
   font-family: RT-Alias-Grotesk;
+  text-align: left;
+  min-width: 64px;
   margin: 0;
   margin-top: 0;
   margin-left: 4px;


### PR DESCRIPTION
# Changes
1. Adds `minWidth` to `Copy` component to avoid positioning glitch (closes #656 
1. Updated `View Address on Ledger` button - I'm going to add a tooltip to explain what this is, once the `feat/add-tooltip` branch is merged.
1. Updates `StyledATag` link to `fontSize=2` (same as all body `Text` elements which will restore consistency) - couldn't help myself.

# Reference
<img width="909" alt="image" src="https://user-images.githubusercontent.com/6787950/95789650-4d921d00-0cb4-11eb-8c19-d2093d5d8af9.png">
