### PR TITLE
Add initial rendering of a Signers component

### DIFF
--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -104,7 +104,10 @@ const AccountSummary = ({
           ) : (
             <>
               <Box position='relative' display='flex' flexWrap='wrap'>
-                <Address address={walletAddress} label='Your Ledger Address' />
+                <Address
+                  address={walletAddress}
+                  label='Signer 1 - Your Ledger'
+                />
 
                 <ButtonViewOnLedgerDevice
                   display='flex'

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -6,7 +6,6 @@ import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import {
   Box,
   Glyph,
-  CopyAddress,
   Text,
   Label,
   BaseButton,
@@ -14,6 +13,7 @@ import {
   IconLedger,
   Tooltip
 } from '../../Shared'
+import Address from './Address'
 import Signers from './Signers'
 
 const ButtonViewOnLedgerDevice = styled(BaseButton)``
@@ -35,36 +35,7 @@ const AccountSummary = ({
       alignItems='center'
       flexWrap='wrap'
     >
-      <Box display='flex' color='card.account.color'>
-        <Box
-          display='flex'
-          alignItems='center'
-          justifyContent='flex-start'
-          color='core.darkgray'
-          bg='background.messageHistory'
-          height={6}
-          px={2}
-          mr={2}
-          my={1}
-          borderRadius={2}
-        >
-          <Glyph
-            mr={3}
-            color='core.nearblack'
-            acronym='Ms'
-            size={5}
-            border={0}
-          />
-          <Box flexGrow='1'>
-            <Label fontSize={1}>Multisig Address</Label>
-            <CopyAddress
-              justifyContent='space-between'
-              color='core.nearblack'
-              address={msigAddress}
-            />
-          </Box>
-        </Box>
-      </Box>
+      <Address label='Multisig Address' address={msigAddress} />
       <Box
         display='flex'
         flexDirection='column'
@@ -127,45 +98,8 @@ const AccountSummary = ({
           </Box>
         ) : (
           <>
-            <Box
-              position='relative'
-              display='flex'
-              flexWrap='wrap'
-              color='card.account.color'
-            >
-              <Box
-                display='flex'
-                alignItems='center'
-                color='core.darkgray'
-                bg='background.messageHistory'
-                height={6}
-                px={2}
-                mr={2}
-                my={1}
-                borderRadius={2}
-              >
-                <Glyph
-                  justifyContent='flex-end'
-                  alignSelf='flex-end'
-                  mb='1px'
-                  mr={3}
-                  size={5}
-                  Icon={IconLedger}
-                  color='core.nearblack'
-                  bg='transparent'
-                  fill='#444'
-                  border={0}
-                  css='transform:translateY(-6px)'
-                />
-                <Box flexGrow='1'>
-                  <Label fontSize={1}>Ledger Address</Label>
-                  <CopyAddress
-                    justifyContent='space-between'
-                    color='core.nearblack'
-                    address={walletAddress}
-                  />
-                </Box>
-              </Box>
+            <Box position='relative' display='flex' flexWrap='wrap'>
+              <Address address={walletAddress} label='Ledger Address' />
 
               <ButtonViewOnLedgerDevice
                 display='flex'

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -40,7 +40,6 @@ const AccountSummary = ({
         label='Multisig Address'
         address={msigAddress}
         glyphAcronym='Ms'
-        maxWidth={11}
       />
       <Box
         display='flex'

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -104,7 +104,7 @@ const AccountSummary = ({
         ) : (
           <>
             <Box position='relative' display='flex' flexWrap='wrap'>
-              <Address address={walletAddress} label='Ledger Address' />
+              <Address address={walletAddress} label='Your Ledger Address' />
 
               <ButtonViewOnLedgerDevice
                 display='flex'

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -35,7 +35,11 @@ const AccountSummary = ({
       alignItems='center'
       flexWrap='wrap'
     >
-      <Address label='Multisig Address' address={msigAddress} />
+      <Address
+        label='Multisig Address'
+        address={msigAddress}
+        glyphAcronym='Ms'
+      />
       <Box
         display='flex'
         flexDirection='column'

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -28,6 +28,7 @@ const AccountSummary = ({
   error
 }) => {
   return (
+    <>
     <Box
       display='flex'
       flexDirection='row'
@@ -39,6 +40,7 @@ const AccountSummary = ({
         label='Multisig Address'
         address={msigAddress}
         glyphAcronym='Ms'
+        maxWidth={11}
       />
       <Box
         display='flex'
@@ -134,8 +136,9 @@ const AccountSummary = ({
           </>
         )}
       </Box>
-      <Signers signers={signers} walletAddress={walletAddress} />
     </Box>
+    <Signers signers={signers} walletAddress={walletAddress} />
+    </>
   )
 }
 

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -29,114 +29,114 @@ const AccountSummary = ({
 }) => {
   return (
     <>
-    <Box
-      display='flex'
-      flexDirection='row'
-      justifyContent='space-between'
-      alignItems='center'
-      flexWrap='wrap'
-    >
-      <Address
-        label='Multisig Address'
-        address={msigAddress}
-        glyphAcronym='Ms'
-      />
       <Box
         display='flex'
-        flexDirection='column'
+        flexDirection='row'
         justifyContent='space-between'
-        borderBottomLeftRadius={3}
-        borderBottomRightRadius={3}
+        alignItems='center'
+        flexWrap='wrap'
       >
-        {error ? (
-          <Box display='flex'>
-            <Box
-              display='flex'
-              alignItems='center'
-              color='core.darkgray'
-              bg='status.fail.background'
-              height={6}
-              px={2}
-              mr={2}
-              my={1}
-              borderRadius={2}
-            >
-              <Glyph
-                justifyContent='flex-end'
-                alignSelf='flex-end'
-                mb='1px'
-                mr={3}
-                size={5}
-                Icon={IconLedger}
-                color='core.nearblack'
-                bg='transparent'
-                fill='#444'
-                border={0}
-                css='transform:translateY(-6px)'
-              />
+        <Address
+          label='Multisig Address'
+          address={msigAddress}
+          glyphAcronym='Ms'
+        />
+        <Box
+          display='flex'
+          flexDirection='column'
+          justifyContent='space-between'
+          borderBottomLeftRadius={3}
+          borderBottomRightRadius={3}
+        >
+          {error ? (
+            <Box display='flex'>
               <Box
                 display='flex'
-                flexDirection='column'
-                flexGrow='1'
-                color='core.nearblack'
+                alignItems='center'
+                color='core.darkgray'
+                bg='status.fail.background'
+                height={6}
+                px={2}
+                mr={2}
+                my={1}
+                borderRadius={2}
               >
-                <Label fontSize={1}>ERROR</Label>
-                {error}
+                <Glyph
+                  justifyContent='flex-end'
+                  alignSelf='flex-end'
+                  mb='1px'
+                  mr={3}
+                  size={5}
+                  Icon={IconLedger}
+                  color='core.nearblack'
+                  bg='transparent'
+                  fill='#444'
+                  border={0}
+                  css='transform:translateY(-6px)'
+                />
+                <Box
+                  display='flex'
+                  flexDirection='column'
+                  flexGrow='1'
+                  color='core.nearblack'
+                >
+                  <Label fontSize={1}>ERROR</Label>
+                  {error}
+                </Box>
               </Box>
-            </Box>
-            <Button
-              type='button'
-              variant='secondary'
-              title='Retry'
-              onClick={reset}
-              display='flex'
-              alignItems='center'
-              minWidth={8}
-              border={1}
-              bg='transparent'
-              borderColor='core.lightgray'
-              my={1}
-              height={6}
-              flexGrow='1'
-              borderRadius={6}
-            />
-          </Box>
-        ) : (
-          <>
-            <Box position='relative' display='flex' flexWrap='wrap'>
-              <Address address={walletAddress} label='Your Ledger Address' />
-
-              <ButtonViewOnLedgerDevice
+              <Button
+                type='button'
+                variant='secondary'
+                title='Retry'
+                onClick={reset}
                 display='flex'
                 alignItems='center'
-                maxWidth={10}
-                onClick={showOnDevice}
-                disabled={ledgerBusy}
+                minWidth={8}
                 border={1}
                 bg='transparent'
-                color='core.nearblack'
+                borderColor='core.lightgray'
                 my={1}
                 height={6}
                 flexGrow='1'
                 borderRadius={6}
-              >
-                <IconLedger size={4} mr={2} />
-                {ledgerBusy ? (
-                  <Text>Check Ledger device</Text>
-                ) : (
-                  <Text>View</Text>
-                )}
-              </ButtonViewOnLedgerDevice>
-              <Tooltip
-                borderColor='core.lightgray'
-                content='Displays your address on your Ledger device'
               />
             </Box>
-          </>
-        )}
+          ) : (
+            <>
+              <Box position='relative' display='flex' flexWrap='wrap'>
+                <Address address={walletAddress} label='Your Ledger Address' />
+
+                <ButtonViewOnLedgerDevice
+                  display='flex'
+                  alignItems='center'
+                  maxWidth={10}
+                  onClick={showOnDevice}
+                  disabled={ledgerBusy}
+                  border={1}
+                  bg='transparent'
+                  color='core.nearblack'
+                  my={1}
+                  height={6}
+                  flexGrow='1'
+                  borderRadius={6}
+                >
+                  <IconLedger size={4} mr={2} />
+                  {ledgerBusy ? (
+                    <Text>Check Ledger device</Text>
+                  ) : (
+                    <Text>View</Text>
+                  )}
+                </ButtonViewOnLedgerDevice>
+                <Tooltip
+                  borderColor='core.lightgray'
+                  content='Displays your address on your Ledger device'
+                />
+              </Box>
+            </>
+          )}
+        </Box>
       </Box>
-    </Box>
-    <Signers signers={signers} walletAddress={walletAddress} />
+      <Signers signers={signers} walletAddress={walletAddress} />
     </>
   )
 }

--- a/components/Msig/Home/AccountSummary.jsx
+++ b/components/Msig/Home/AccountSummary.jsx
@@ -14,6 +14,7 @@ import {
   IconLedger,
   Tooltip
 } from '../../Shared'
+import Signers from './Signers'
 
 const ButtonViewOnLedgerDevice = styled(BaseButton)``
 
@@ -21,6 +22,7 @@ const AccountSummary = ({
   msigAddress,
   showOnDevice,
   walletAddress,
+  signers,
   reset,
   ledgerBusy,
   error
@@ -194,6 +196,7 @@ const AccountSummary = ({
           </>
         )}
       </Box>
+      <Signers signers={signers} walletAddress={walletAddress} />
     </Box>
   )
 }
@@ -204,7 +207,13 @@ AccountSummary.propTypes = {
   showOnDevice: PropTypes.func.isRequired,
   ledgerBusy: PropTypes.bool.isRequired,
   error: PropTypes.string,
-  reset: PropTypes.func.isRequired
+  reset: PropTypes.func.isRequired,
+  signers: PropTypes.arrayOf(
+    PropTypes.shape({
+      account: ADDRESS_PROPTYPE,
+      id: ADDRESS_PROPTYPE
+    })
+  ).isRequired
 }
 
 AccountSummary.defaultProps = {

--- a/components/Msig/Home/Address.jsx
+++ b/components/Msig/Home/Address.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
-import { Box, Glyph, CopyAddress, Label } from '../../Shared'
+import { Box, Glyph, CopyAddress, Label, IconLedger } from '../../Shared'
 
-const Address = ({ address, label, isOwnerAddress }) => {
+const Address = ({ address, label, isOwnerAddress, glyphAcronym }) => {
   return (
     <Box display='flex' color={isOwnerAddress ? 'card.account.color' : 'red'}>
       <Box
@@ -19,7 +19,29 @@ const Address = ({ address, label, isOwnerAddress }) => {
         my={1}
         borderRadius={2}
       >
-        <Glyph mr={3} color='core.nearblack' acronym='Ms' size={5} border={0} />
+        {glyphAcronym ? (
+          <Glyph
+            mr={3}
+            color='core.nearblack'
+            acronym={glyphAcronym}
+            size={5}
+            border={0}
+          />
+        ) : (
+          <Glyph
+            justifyContent='flex-end'
+            alignSelf='flex-end'
+            mb='1px'
+            mr={3}
+            size={5}
+            Icon={IconLedger}
+            color='core.nearblack'
+            bg='transparent'
+            fill='#444'
+            border={0}
+            css='transform:translateY(-6px)'
+          />
+        )}
         <Box flexGrow='1'>
           <Label fontSize={1}>{label}</Label>
           <CopyAddress
@@ -36,7 +58,8 @@ const Address = ({ address, label, isOwnerAddress }) => {
 Address.propTypes = {
   address: ADDRESS_PROPTYPE,
   label: PropTypes.string.isRequired,
-  isOwnerAddress: PropTypes.bool
+  isOwnerAddress: PropTypes.bool,
+  glyphAcronym: PropTypes.string
 }
 
 Address.propTypes = {

--- a/components/Msig/Home/Address.jsx
+++ b/components/Msig/Home/Address.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+
+import { Box, Glyph, CopyAddress, Label } from '../../Shared'
+
+const Address = ({ address, label, isOwnerAddress }) => {
+  return (
+    <Box display='flex' color={isOwnerAddress ? 'card.account.color' : 'red'}>
+      <Box
+        display='flex'
+        alignItems='center'
+        justifyContent='flex-start'
+        color='core.darkgray'
+        bg='background.messageHistory'
+        height={6}
+        px={2}
+        mr={2}
+        my={1}
+        borderRadius={2}
+      >
+        <Glyph mr={3} color='core.nearblack' acronym='Ms' size={5} border={0} />
+        <Box flexGrow='1'>
+          <Label fontSize={1}>{label}</Label>
+          <CopyAddress
+            justifyContent='space-between'
+            color='core.nearblack'
+            address={address}
+          />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+Address.propTypes = {
+  address: ADDRESS_PROPTYPE,
+  label: PropTypes.string.isRequired,
+  isOwnerAddress: PropTypes.bool
+}
+
+Address.propTypes = {
+  isOwnerAddress: false
+}
+
+export default Address

--- a/components/Msig/Home/Address.jsx
+++ b/components/Msig/Home/Address.jsx
@@ -6,51 +6,51 @@ import { Box, Glyph, CopyAddress, Label, IconLedger } from '../../Shared'
 
 const Address = ({ address, label, glyphAcronym }) => {
   return (
-      <Box
-        display='flex'
-        alignItems='center'
-        justifyContent='flex-start'
-        color='core.darkgray'
-        bg='background.messageHistory'
-        height={6}
-        px={2}
-        mr={2}
-        my={1}
-        borderRadius={2}
-        maxWidth={11}
-      >
-        {glyphAcronym ? (
-          <Glyph
-            mr={3}
-            color='core.nearblack'
-            acronym={glyphAcronym}
-            size={5}
-            border={0}
-          />
-        ) : (
-          <Glyph
-            justifyContent='flex-end'
-            alignSelf='flex-end'
-            mb='1px'
-            mr={3}
-            size={5}
-            Icon={IconLedger}
-            color='core.nearblack'
-            bg='transparent'
-            fill='#444'
-            border={0}
-            css='transform:translateY(-6px)'
-          />
-        )}
-        <Box flexGrow='1'>
-          <Label fontSize={1}>{label}</Label>
-          <CopyAddress
-            justifyContent='space-between'
-            color='core.nearblack'
-            address={address}
-          />
-        </Box>
+    <Box
+      display='flex'
+      alignItems='center'
+      justifyContent='flex-start'
+      color='core.darkgray'
+      bg='background.messageHistory'
+      height={6}
+      px={2}
+      mr={2}
+      my={1}
+      borderRadius={2}
+      maxWidth={11}
+    >
+      {glyphAcronym ? (
+        <Glyph
+          mr={3}
+          color='core.nearblack'
+          acronym={glyphAcronym}
+          size={5}
+          border={0}
+        />
+      ) : (
+        <Glyph
+          justifyContent='flex-end'
+          alignSelf='flex-end'
+          mb='1px'
+          mr={3}
+          size={5}
+          Icon={IconLedger}
+          color='core.nearblack'
+          bg='transparent'
+          fill='#444'
+          border={0}
+          css='transform:translateY(-6px)'
+        />
+      )}
+      <Box flexGrow='1'>
+        <Label fontSize={1}>{label}</Label>
+        <CopyAddress
+          justifyContent='space-between'
+          color='core.nearblack'
+          address={address}
+        />
       </Box>
+    </Box>
   )
 }
 

--- a/components/Msig/Home/Address.jsx
+++ b/components/Msig/Home/Address.jsx
@@ -4,7 +4,7 @@ import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
 import { Box, Glyph, CopyAddress, Label, IconLedger } from '../../Shared'
 
-const Address = ({ address, label, isOwnerAddress, glyphAcronym }) => {
+const Address = ({ address, label, glyphAcronym }) => {
   return (
     <Box display='flex'>
       <Box
@@ -59,12 +59,7 @@ const Address = ({ address, label, isOwnerAddress, glyphAcronym }) => {
 Address.propTypes = {
   address: ADDRESS_PROPTYPE,
   label: PropTypes.string.isRequired,
-  isOwnerAddress: PropTypes.bool,
   glyphAcronym: PropTypes.string
-}
-
-Address.propTypes = {
-  isOwnerAddress: false
 }
 
 export default Address

--- a/components/Msig/Home/Address.jsx
+++ b/components/Msig/Home/Address.jsx
@@ -6,7 +6,7 @@ import { Box, Glyph, CopyAddress, Label, IconLedger } from '../../Shared'
 
 const Address = ({ address, label, isOwnerAddress, glyphAcronym }) => {
   return (
-    <Box display='flex' color={isOwnerAddress ? 'card.account.color' : 'red'}>
+    <Box display='flex'>
       <Box
         display='flex'
         alignItems='center'
@@ -18,6 +18,7 @@ const Address = ({ address, label, isOwnerAddress, glyphAcronym }) => {
         mr={2}
         my={1}
         borderRadius={2}
+        maxWidth={11}
       >
         {glyphAcronym ? (
           <Glyph

--- a/components/Msig/Home/Address.jsx
+++ b/components/Msig/Home/Address.jsx
@@ -6,7 +6,6 @@ import { Box, Glyph, CopyAddress, Label, IconLedger } from '../../Shared'
 
 const Address = ({ address, label, glyphAcronym }) => {
   return (
-    <Box display='flex'>
       <Box
         display='flex'
         alignItems='center'
@@ -52,7 +51,6 @@ const Address = ({ address, label, glyphAcronym }) => {
           />
         </Box>
       </Box>
-    </Box>
   )
 }
 

--- a/components/Msig/Home/Balances.jsx
+++ b/components/Msig/Home/Balances.jsx
@@ -102,7 +102,7 @@ const Balances = ({ available, setWithdrawing, total }) => {
         width='100%'
         p={6}
       >
-        <Title fontSize={2}>Total Vesting</Title>
+        <Title fontSize={2} mb={5}>Total Vesting</Title>
         <TotalBalance total={total} />
       </Box>
     </Box>

--- a/components/Msig/Home/Balances.jsx
+++ b/components/Msig/Home/Balances.jsx
@@ -102,7 +102,9 @@ const Balances = ({ available, setWithdrawing, total }) => {
         width='100%'
         p={6}
       >
-        <Title fontSize={2} mb={5}>Total Vesting</Title>
+        <Title fontSize={2} mb={5}>
+          Total Vesting
+        </Title>
         <TotalBalance total={total} />
       </Box>
     </Box>

--- a/components/Msig/Home/Signers.jsx
+++ b/components/Msig/Home/Signers.jsx
@@ -20,7 +20,7 @@ const Signers = ({ signers, walletAddress }) => {
           return (
             <Address
               key={signer.account}
-              label='Signer'
+              label='Additional Signer'
               address={truncateAddress(signer.account)}
               glyphAcronym={i + 1}
             />

--- a/components/Msig/Home/Signers.jsx
+++ b/components/Msig/Home/Signers.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
-import { Box, Text } from '../../Shared'
+import { Box } from '../../Shared'
 import converAddrToFPrefix from '../../../utils/convertAddrToFPrefix'
 import truncateAddress from '../../../utils/truncateAddress'
 import Address from './Address'
@@ -10,17 +10,22 @@ import Address from './Address'
 const Signers = ({ signers, walletAddress }) => {
   return (
     <Box display='flex' flexWrap='wrap'>
-      {signers.map((signer, i) => {
-        const isOwner = converAddrToFPrefix(signer.account) === converAddrToFPrefix(walletAddress)
-        return (
-          <Address
-            key={signer.account}
-            label={isOwner ? 'Your Ledger Address' : 'Signer'}
-            address={truncateAddress(signer.account)}
-            glyphAcronym={i + 1}
-          />
+      {signers
+        .filter(
+          signer =>
+            converAddrToFPrefix(signer.account) !==
+            converAddrToFPrefix(walletAddress)
         )
-      })}
+        .map((signer, i) => {
+          return (
+            <Address
+              key={signer.account}
+              label='Signer'
+              address={truncateAddress(signer.account)}
+              glyphAcronym={i + 1}
+            />
+          )
+        })}
     </Box>
   )
 }

--- a/components/Msig/Home/Signers.jsx
+++ b/components/Msig/Home/Signers.jsx
@@ -9,16 +9,14 @@ import Address from './Address'
 
 const Signers = ({ signers, walletAddress }) => {
   return (
-    <Box>
-      <Text>Signers</Text>
+    <Box display='flex' flexWrap='wrap'>
       {signers.map((signer, i) => {
-        const isOwner = converAddrToFPrefix(signer.account) === walletAddress
+        const isOwner = converAddrToFPrefix(signer.account) === converAddrToFPrefix(walletAddress)
         return (
           <Address
             key={signer.account}
             label={isOwner ? 'Your Ledger Address' : 'Signer'}
             address={truncateAddress(signer.account)}
-            isOwnerAddress={isOwner}
             glyphAcronym={i + 1}
           />
         )

--- a/components/Msig/Home/Signers.jsx
+++ b/components/Msig/Home/Signers.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+import { Box, Text } from '../../Shared'
+import converAddrToFPrefix from '../../../utils/convertAddrToFPrefix'
+import truncateAddress from '../../../utils/truncateAddress'
+
+const Signers = ({ signers, walletAddress }) => {
+  return (
+    <Box>
+      <Text>Signers</Text>
+      {signers.map(signer => {
+        if (converAddrToFPrefix(signer.account) === walletAddress) {
+          return (
+            <Box display='flex' key={signer.account}>
+              <Text mr={2} color='core.primary'>
+                Your ledger address:{' '}
+              </Text>
+              <Text>{truncateAddress(signer.account)}</Text>
+            </Box>
+          )
+        }
+        return (
+          <Text key={signer.account}>{truncateAddress(signer.account)}</Text>
+        )
+      })}
+    </Box>
+  )
+}
+
+Signers.propTypes = {
+  signers: PropTypes.arrayOf(
+    PropTypes.shape({
+      account: ADDRESS_PROPTYPE,
+      id: ADDRESS_PROPTYPE
+    })
+  ).isRequired,
+  walletAddress: ADDRESS_PROPTYPE
+}
+
+export default Signers

--- a/components/Msig/Home/Signers.jsx
+++ b/components/Msig/Home/Signers.jsx
@@ -11,7 +11,7 @@ const Signers = ({ signers, walletAddress }) => {
   return (
     <Box>
       <Text>Signers</Text>
-      {signers.map(signer => {
+      {signers.map((signer, i) => {
         const isOwner = converAddrToFPrefix(signer.account) === walletAddress
         return (
           <Address
@@ -19,6 +19,7 @@ const Signers = ({ signers, walletAddress }) => {
             label={isOwner ? 'Your Ledger Address' : 'Signer'}
             address={truncateAddress(signer.account)}
             isOwnerAddress={isOwner}
+            glyphAcronym={i + 1}
           />
         )
       })}

--- a/components/Msig/Home/Signers.jsx
+++ b/components/Msig/Home/Signers.jsx
@@ -5,24 +5,21 @@ import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import { Box, Text } from '../../Shared'
 import converAddrToFPrefix from '../../../utils/convertAddrToFPrefix'
 import truncateAddress from '../../../utils/truncateAddress'
+import Address from './Address'
 
 const Signers = ({ signers, walletAddress }) => {
   return (
     <Box>
       <Text>Signers</Text>
       {signers.map(signer => {
-        if (converAddrToFPrefix(signer.account) === walletAddress) {
-          return (
-            <Box display='flex' key={signer.account}>
-              <Text mr={2} color='core.primary'>
-                Your ledger address:{' '}
-              </Text>
-              <Text>{truncateAddress(signer.account)}</Text>
-            </Box>
-          )
-        }
+        const isOwner = converAddrToFPrefix(signer.account) === walletAddress
         return (
-          <Text key={signer.account}>{truncateAddress(signer.account)}</Text>
+          <Address
+            key={signer.account}
+            label={isOwner ? 'Your Ledger Address' : 'Signer'}
+            address={truncateAddress(signer.account)}
+            isOwnerAddress={isOwner}
+          />
         )
       })}
     </Box>

--- a/components/Msig/Home/State.jsx
+++ b/components/Msig/Home/State.jsx
@@ -5,7 +5,7 @@ import {
   ADDRESS_PROPTYPE,
   FILECOIN_NUMBER_PROP
 } from '../../../customPropTypes'
-import { Box, Button, Title, Menu, MenuItem, IconGlif } from '../../Shared'
+import { Box, Button, Title, Text, Menu, MenuItem, IconGlif } from '../../Shared'
 import AccountSummary from './AccountSummary'
 import useWallet from '../../../WalletProvider/useWallet'
 import { useWalletProvider } from '../../../WalletProvider'
@@ -65,15 +65,33 @@ const State = ({
             />
             <Title ml={2}>Vault</Title>
           </Box>
+          <Box display='flex' alignItems='center'>
+            <Text color='core.darkgray' mx={4} my={0}>SIGNER</Text>
           <Button
             type='button'
             variant='secondary'
             onClick={setAddSigner}
-            title='Add Signer'
-            maxWidth={10}
-            minWidth={9}
+            title='Add'
+
+            minWidth={8}
+            height='40px'
             borderRadius={6}
+            m={1}
           />
+           {showRmSignerOption && (
+              <Button
+                type='button'
+                variant='secondary'
+                onClick={setRmSigner}
+                title='Remove'
+
+                minWidth={8}
+                height='40px'
+                borderRadius={6}
+                m={1}
+              />
+            )}
+            </Box>
         </MenuItem>
         <Menu
           display='flex'
@@ -108,17 +126,6 @@ const State = ({
                 onClick={setChangingOwner}
                 title='Change Signer'
                 height={6}
-                maxWidth={10}
-                minWidth={9}
-                borderRadius={6}
-              />
-            )}
-            {showRmSignerOption && (
-              <Button
-                type='button'
-                variant='secondary'
-                onClick={setRmSigner}
-                title='Remove Signer'
                 maxWidth={10}
                 minWidth={9}
                 borderRadius={6}

--- a/components/Msig/Home/State.jsx
+++ b/components/Msig/Home/State.jsx
@@ -13,6 +13,7 @@ import { reportLedgerConfigError } from '../../../utils/ledger/reportLedgerConfi
 import MessageHistory from '../MessageHistory'
 
 const State = ({
+  signers,
   msigAddress,
   available,
   setChangingOwner,
@@ -91,6 +92,7 @@ const State = ({
             <AccountSummary
               msigAddress={msigAddress}
               walletAddress={walletAddress}
+              signers={signers}
               showOnDevice={onShowOnLedger}
               ledgerBusy={ledgerBusy}
               error={reportLedgerConfigError({
@@ -162,6 +164,12 @@ State.propTypes = {
   setWithdrawing: PropTypes.func.isRequired,
   setRmSigner: PropTypes.func.isRequired,
   setAddSigner: PropTypes.func.isRequired,
+  signers: PropTypes.arrayOf(
+    PropTypes.shape({
+      account: ADDRESS_PROPTYPE,
+      id: ADDRESS_PROPTYPE
+    })
+  ).isRequired,
   showRmSignerOption: PropTypes.bool.isRequired,
   showChangeOwnerOption: PropTypes.bool.isRequired
 }

--- a/components/Msig/Home/State.jsx
+++ b/components/Msig/Home/State.jsx
@@ -5,7 +5,15 @@ import {
   ADDRESS_PROPTYPE,
   FILECOIN_NUMBER_PROP
 } from '../../../customPropTypes'
-import { Box, Button, Title, Text, Menu, MenuItem, IconGlif } from '../../Shared'
+import {
+  Box,
+  Button,
+  Title,
+  Text,
+  Menu,
+  MenuItem,
+  IconGlif
+} from '../../Shared'
 import AccountSummary from './AccountSummary'
 import useWallet from '../../../WalletProvider/useWallet'
 import { useWalletProvider } from '../../../WalletProvider'
@@ -66,32 +74,32 @@ const State = ({
             <Title ml={2}>Vault</Title>
           </Box>
           <Box display='flex' alignItems='center'>
-            <Text color='core.darkgray' mx={4} my={0}>SIGNER</Text>
-          <Button
-            type='button'
-            variant='secondary'
-            onClick={setAddSigner}
-            title='Add'
-
-            minWidth={8}
-            height='40px'
-            borderRadius={6}
-            m={1}
-          />
-           {showRmSignerOption && (
+            <Text color='core.darkgray' mx={4} my={0}>
+              SIGNER
+            </Text>
+            <Button
+              type='button'
+              variant='secondary'
+              onClick={setAddSigner}
+              title='Add'
+              minWidth={8}
+              height='40px'
+              borderRadius={6}
+              m={1}
+            />
+            {showRmSignerOption && (
               <Button
                 type='button'
                 variant='secondary'
                 onClick={setRmSigner}
                 title='Remove'
-
                 minWidth={8}
                 height='40px'
                 borderRadius={6}
                 m={1}
               />
             )}
-            </Box>
+          </Box>
         </MenuItem>
         <Menu
           display='flex'

--- a/components/Msig/Home/index.jsx
+++ b/components/Msig/Home/index.jsx
@@ -44,6 +44,7 @@ const MsigHome = () => {
             setWithdrawing={() => setChildView(WITHDRAW)}
             setRmSigner={() => setChildView(REMOVE_SIGNER)}
             setAddSigner={() => setChildView(ADD_SIGNER)}
+            signers={msig.Signers}
             showRmSignerOption={msig.Signers.length > 1}
             showChangeOwnerOption={msig.Signers.length === 1}
           />

--- a/components/Shared/AccountCard/__snapshots__/index.test.js.snap
+++ b/components/Shared/AccountCard/__snapshots__/index.test.js.snap
@@ -87,7 +87,7 @@ exports[`AccountCard renders the card 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -102,7 +102,7 @@ exports[`AccountCard renders the card 1`] = `
   font-size: 1.5rem;
 }
 
-.c16 {
+.c17 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -124,11 +124,11 @@ exports[`AccountCard renders the card 1`] = `
   border-radius: 4px;
 }
 
-.c16:hover {
+.c17:hover {
   opacity: 0.8;
 }
 
-.c17 {
+.c18 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -151,11 +151,11 @@ exports[`AccountCard renders the card 1`] = `
   border-radius: 4px;
 }
 
-.c17:hover {
+.c18:hover {
   opacity: 0.8;
 }
 
-.c11 {
+.c12 {
   width: 24;
   height: 24;
 }
@@ -165,7 +165,6 @@ exports[`AccountCard renders the card 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
-  overflow: hidden;
   margin: 0;
 }
 
@@ -184,7 +183,7 @@ exports[`AccountCard renders the card 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c14 {
   color: #E0D7FE;
   font-size: 1.125rem;
   font-weight: 400;
@@ -197,7 +196,11 @@ exports[`AccountCard renders the card 1`] = `
   margin-left: 4px;
 }
 
-.c10 {
+.c9 {
+  white-space: nowrap;
+}
+
+.c11 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -231,28 +234,28 @@ exports[`AccountCard renders the card 1`] = `
   outline: none;
 }
 
-.c10:hover {
+.c11:hover {
   opacity: 0.8;
 }
 
-.c12 {
+.c13 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c9:hover .c12 {
+.c10:hover .c13 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c14 {
+.c15 {
   -webkit-transition: 0.18s ease-in;
   transition: 0.18s ease-in;
   opacity: 0;
 }
 
-.c9:hover .c14 {
+.c10:hover .c15 {
   opacity: 1;
 }
 
@@ -307,22 +310,21 @@ exports[`AccountCard renders the card 1`] = `
       display="flex"
     >
       <h2
-        class="c8"
+        class="c8 c9"
         font-family="RT-Alias-Grotesk"
         font-size="3"
         font-weight="1"
-        overflow="hidden"
       >
         t01234 ... 456789
       </h2>
       <button
-        class="c9 c10"
+        class="c10 c11"
         display="flex"
         font-size="3"
         height="6"
       >
         <svg
-          class="c11 c12"
+          class="c12 c13"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -345,7 +347,7 @@ exports[`AccountCard renders the card 1`] = `
           />
         </svg>
         <h4
-          class="c13 c14"
+          class="c14 c15"
           color="core.secondary"
           font-family="RT-Alias-Grotesk"
           font-size="2"
@@ -357,11 +359,11 @@ exports[`AccountCard renders the card 1`] = `
     </div>
   </div>
   <div
-    class="c15"
+    class="c16"
     display="flex"
   >
     <button
-      class="c16"
+      class="c17"
       font-size="3"
       height="max-content"
       type="button"
@@ -369,7 +371,7 @@ exports[`AccountCard renders the card 1`] = `
       Switch
     </button>
     <button
-      class="c17"
+      class="c18"
       font-size="3"
       height="max-content"
       type="button"
@@ -467,7 +469,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -482,7 +484,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   font-size: 1.5rem;
 }
 
-.c16 {
+.c17 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -504,11 +506,11 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   border-radius: 4px;
 }
 
-.c16:hover {
+.c17:hover {
   opacity: 0.8;
 }
 
-.c11 {
+.c12 {
   width: 24;
   height: 24;
 }
@@ -518,7 +520,6 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
-  overflow: hidden;
   margin: 0;
 }
 
@@ -537,7 +538,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   margin: 0;
 }
 
-.c13 {
+.c14 {
   color: #E0D7FE;
   font-size: 1.125rem;
   font-weight: 400;
@@ -550,7 +551,11 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   margin-left: 4px;
 }
 
-.c10 {
+.c9 {
+  white-space: nowrap;
+}
+
+.c11 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -584,28 +589,28 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
   outline: none;
 }
 
-.c10:hover {
+.c11:hover {
   opacity: 0.8;
 }
 
-.c12 {
+.c13 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c9:hover .c12 {
+.c10:hover .c13 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c14 {
+.c15 {
   -webkit-transition: 0.18s ease-in;
   transition: 0.18s ease-in;
   opacity: 0;
 }
 
-.c9:hover .c14 {
+.c10:hover .c15 {
   opacity: 1;
 }
 
@@ -660,22 +665,21 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
       display="flex"
     >
       <h2
-        class="c8"
+        class="c8 c9"
         font-family="RT-Alias-Grotesk"
         font-size="3"
         font-weight="1"
-        overflow="hidden"
       >
         t01234 ... 456789
       </h2>
       <button
-        class="c9 c10"
+        class="c10 c11"
         display="flex"
         font-size="3"
         height="6"
       >
         <svg
-          class="c11 c12"
+          class="c12 c13"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -698,7 +702,7 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
           />
         </svg>
         <h4
-          class="c13 c14"
+          class="c14 c15"
           color="core.secondary"
           font-family="RT-Alias-Grotesk"
           font-size="2"
@@ -710,11 +714,11 @@ exports[`AccountCard renders the card CREATE_MNEMONIC 1`] = `
     </div>
   </div>
   <div
-    class="c15"
+    class="c16"
     display="flex"
   >
     <button
-      class="c16"
+      class="c17"
       font-size="3"
       height="max-content"
       type="button"

--- a/components/Shared/Copy/index.jsx
+++ b/components/Shared/Copy/index.jsx
@@ -4,13 +4,13 @@ import { string } from 'prop-types'
 import Box from '../Box'
 import BaseButton from '../Button/BaseButton'
 import { IconCopyAccountAddress } from '../Icons'
-import { Label, Title} from '../Typography'
+import { Label, Title } from '../Typography'
 import truncate from '../../../utils/truncateAddress'
 import copyToClipboard from '../../../utils/copyToClipboard'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 
 const AccountAddress = styled(Title)`
-white-space: nowrap;
+  white-space: nowrap;
 `
 
 const Copy = styled(BaseButton)`
@@ -42,11 +42,7 @@ export const CopyAddress = forwardRef(({ address, ...props }, ref) => {
   const [copied, setCopied] = useState(false)
   return (
     <Box ref={ref} display='flex' alignItems='center' {...props}>
-      <AccountAddress
-        fontWeight={1}
-        fontSize={3}
-        margin={0}
-      >
+      <AccountAddress fontWeight={1} fontSize={3} margin={0}>
         {truncate(address)}
       </AccountAddress>
       <Copy

--- a/components/Shared/Copy/index.jsx
+++ b/components/Shared/Copy/index.jsx
@@ -4,10 +4,14 @@ import { string } from 'prop-types'
 import Box from '../Box'
 import BaseButton from '../Button/BaseButton'
 import { IconCopyAccountAddress } from '../Icons'
-import { Label, Title as AccountAddress } from '../Typography'
+import { Label, Title} from '../Typography'
 import truncate from '../../../utils/truncateAddress'
 import copyToClipboard from '../../../utils/copyToClipboard'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+
+const AccountAddress = styled(Title)`
+white-space: nowrap;
+`
 
 const Copy = styled(BaseButton)`
   /* !important is declared here to override BaseButton's opacity:0.8 on hover. The only instance of us using this declaration. */
@@ -42,8 +46,6 @@ export const CopyAddress = forwardRef(({ address, ...props }, ref) => {
         fontWeight={1}
         fontSize={3}
         margin={0}
-        overflow='hidden'
-        whiteSpace='nowrap'
       >
         {truncate(address)}
       </AccountAddress>

--- a/components/Wallet/__snapshots__/index.test.js.snap
+++ b/components/Wallet/__snapshots__/index.test.js.snap
@@ -87,7 +87,7 @@ exports[`WalletView it renders correctly 1`] = `
   align-items: center;
 }
 
-.c17 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -96,7 +96,7 @@ exports[`WalletView it renders correctly 1`] = `
   display: flex;
 }
 
-.c19 {
+.c20 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -118,7 +118,7 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c20 {
+.c21 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -134,13 +134,13 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c24 {
+.c25 {
   min-width: 0;
   box-sizing: border-box;
   width: 8px;
 }
 
-.c26 {
+.c27 {
   min-width: 0;
   box-sizing: border-box;
   padding-top: 24px;
@@ -148,7 +148,7 @@ exports[`WalletView it renders correctly 1`] = `
   overflow: hidden;
 }
 
-.c29 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -161,7 +161,7 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c32 {
+.c33 {
   min-width: 0;
   box-sizing: border-box;
   position: relative;
@@ -169,7 +169,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin-right: 8px;
 }
 
-.c39 {
+.c40 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -184,14 +184,14 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: center;
 }
 
-.c40 {
+.c41 {
   min-width: 0;
   box-sizing: border-box;
   border: none;
   width: 100%;
 }
 
-.c41 {
+.c42 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -208,7 +208,7 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: space-between;
 }
 
-.c42 {
+.c43 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -231,7 +231,7 @@ exports[`WalletView it renders correctly 1`] = `
   font-size: 1.5rem;
 }
 
-.c18 {
+.c19 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -253,11 +253,11 @@ exports[`WalletView it renders correctly 1`] = `
   border-radius: 4px;
 }
 
-.c18:hover {
+.c19:hover {
   opacity: 0.8;
 }
 
-.c30 {
+.c31 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -280,11 +280,11 @@ exports[`WalletView it renders correctly 1`] = `
   border-radius: 4px;
 }
 
-.c30:hover {
+.c31:hover {
   opacity: 0.8;
 }
 
-.c44 {
+.c45 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -303,16 +303,16 @@ exports[`WalletView it renders correctly 1`] = `
   border-radius: 4px;
 }
 
-.c44:hover {
+.c45:hover {
   opacity: 0.8;
 }
 
-.c13 {
+.c14 {
   width: 24;
   height: 24;
 }
 
-.c50 {
+.c51 {
   width: 34;
   height: 34;
 }
@@ -322,11 +322,10 @@ exports[`WalletView it renders correctly 1`] = `
   font-weight: 400;
   line-height: 1.2;
   font-family: RT-Alias-Grotesk;
-  overflow: hidden;
   margin: 0;
 }
 
-.c27 {
+.c28 {
   color: #262626;
   font-size: 3rem;
   font-weight: 700;
@@ -350,7 +349,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c34 {
+.c35 {
   color: #000;
   font-size: 1.125rem;
   font-weight: 400;
@@ -359,7 +358,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c37 {
+.c38 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.4;
@@ -369,7 +368,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c43 {
+.c44 {
   color: #5E26FF;
   font-size: 1.125rem;
   font-weight: 400;
@@ -377,7 +376,7 @@ exports[`WalletView it renders correctly 1`] = `
   font-family: RT-Alias-Grotesk;
 }
 
-.c54 {
+.c55 {
   color: #262626;
   font-size: 1.25rem;
   font-weight: 400;
@@ -386,7 +385,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c56 {
+.c57 {
   color: #666666;
   font-size: 1.125rem;
   font-weight: 400;
@@ -395,7 +394,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c60 {
+.c61 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -404,7 +403,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c63 {
+.c64 {
   color: #5E26FF;
   font-size: 1.125rem;
   font-weight: 400;
@@ -414,7 +413,7 @@ exports[`WalletView it renders correctly 1`] = `
   width: 100%;
 }
 
-.c15 {
+.c16 {
   color: #E0D7FE;
   font-size: 1.125rem;
   font-weight: 400;
@@ -427,7 +426,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin-left: 4px;
 }
 
-.c21 {
+.c22 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1;
@@ -435,7 +434,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c22 {
+.c23 {
   color: #000;
   font-size: 1.125rem;
   font-weight: 400;
@@ -444,7 +443,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c26 {
   color: #666666;
   font-size: 1.125rem;
   font-weight: 400;
@@ -453,7 +452,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0;
 }
 
-.c53 {
+.c54 {
   color: #262626;
   font-size: 1.125rem;
   font-weight: 400;
@@ -464,7 +463,11 @@ exports[`WalletView it renders correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c12 {
+.c11 {
+  white-space: nowrap;
+}
+
+.c13 {
   cursor: pointer;
   border: 1px solid #1AD08F;
   background-color: #1AD08F;
@@ -498,42 +501,42 @@ exports[`WalletView it renders correctly 1`] = `
   outline: none;
 }
 
-.c12:hover {
+.c13:hover {
   opacity: 0.8;
 }
 
-.c14 {
+.c15 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c11:hover .c14 {
+.c12:hover .c15 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c16 {
+.c17 {
   -webkit-transition: 0.18s ease-in;
   transition: 0.18s ease-in;
   opacity: 0;
 }
 
-.c11:hover .c16 {
+.c12:hover .c17 {
   opacity: 1;
 }
 
-.c23:hover {
+.c24:hover {
   cursor: pointer;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c28 {
+.c29 {
   word-wrap: break-word;
 }
 
-.c45 {
+.c46 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 4px;
@@ -567,18 +570,18 @@ exports[`WalletView it renders correctly 1`] = `
   transition: 0.18s ease-in-out;
 }
 
-.c45:hover {
+.c46:hover {
   cursor: pointer;
   background-color: #EFF3FD;
 }
 
-.c46 {
+.c47 {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.c48 {
+.c49 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -595,7 +598,7 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: center;
 }
 
-.c51 {
+.c52 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -606,7 +609,7 @@ exports[`WalletView it renders correctly 1`] = `
   display: flex;
 }
 
-.c57 {
+.c58 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -627,7 +630,7 @@ exports[`WalletView it renders correctly 1`] = `
   flex-grow: 999;
 }
 
-.c58 {
+.c59 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -645,7 +648,7 @@ exports[`WalletView it renders correctly 1`] = `
   align-items: flex-end;
 }
 
-.c61 {
+.c62 {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -663,7 +666,7 @@ exports[`WalletView it renders correctly 1`] = `
   align-items: flex-start;
 }
 
-.c47 {
+.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -673,16 +676,16 @@ exports[`WalletView it renders correctly 1`] = `
   flex-direction: row;
 }
 
-.c49 {
+.c50 {
   position: relative;
 }
 
-.c52 {
+.c53 {
   overflow: hidden;
   width: 160px;
 }
 
-.c55 {
+.c56 {
   margin-left: 24px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -698,14 +701,14 @@ exports[`WalletView it renders correctly 1`] = `
   justify-content: center;
 }
 
-.c59 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c62 {
+.c63 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 4px;
@@ -740,12 +743,12 @@ exports[`WalletView it renders correctly 1`] = `
   cursor: pointer;
 }
 
-.c62:hover {
+.c63:hover {
   cursor: pointer;
   background-color: #EFF3FD;
 }
 
-.c36 {
+.c37 {
   min-width: 0;
   box-sizing: border-box;
   border-radius: 16px;
@@ -774,7 +777,7 @@ exports[`WalletView it renders correctly 1`] = `
   transition: 0.24s ease-in-out;
 }
 
-.c33 {
+.c34 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -799,7 +802,7 @@ exports[`WalletView it renders correctly 1`] = `
   color: #000;
 }
 
-.c33:hover ~ .c35 {
+.c34:hover ~ .c36 {
   display: block;
 }
 
@@ -811,7 +814,7 @@ exports[`WalletView it renders correctly 1`] = `
   margin: 0.5rem 0.5rem 0.5rem 0.5rem;
 }
 
-.c38 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -845,7 +848,7 @@ exports[`WalletView it renders correctly 1`] = `
   min-height: 100vh;
 }
 
-.c31 {
+.c32 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -879,22 +882,22 @@ exports[`WalletView it renders correctly 1`] = `
   background-color: #E0D7FE00;
 }
 
-.c31:hover {
+.c32:hover {
   opacity: 0.8;
 }
 
-.c31:hover {
+.c32:hover {
   background-color: #E0D7FE;
 }
 
 @media screen and (min-width:40em) {
-  .c51 {
+  .c52 {
     margin-left: 24px;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c51 {
+  .c52 {
     margin-left: 32px;
   }
 }
@@ -957,22 +960,21 @@ exports[`WalletView it renders correctly 1`] = `
           display="flex"
         >
           <h2
-            class="c10"
+            class="c10 c11"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="1"
-            overflow="hidden"
           >
             t1z225 ... 6z6wgi
           </h2>
           <button
-            class="c11 c12"
+            class="c12 c13"
             display="flex"
             font-size="3"
             height="6"
           >
             <svg
-              class="c13 c14"
+              class="c14 c15"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -995,7 +997,7 @@ exports[`WalletView it renders correctly 1`] = `
               />
             </svg>
             <h4
-              class="c15 c16"
+              class="c16 c17"
               color="core.secondary"
               font-family="RT-Alias-Grotesk"
               font-size="2"
@@ -1007,11 +1009,11 @@ exports[`WalletView it renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="c17"
+        class="c18"
         display="flex"
       >
         <button
-          class="c18"
+          class="c19"
           font-size="3"
           height="max-content"
           type="button"
@@ -1021,16 +1023,16 @@ exports[`WalletView it renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="c19"
+      class="c20"
       display="flex"
       width="300px"
     >
       <div
-        class="c20"
+        class="c21"
         display="flex"
       >
         <h4
-          class="c21"
+          class="c22"
           font-family="RT-Alias-Grotesk"
           font-size="2"
           font-weight="400"
@@ -1038,11 +1040,11 @@ exports[`WalletView it renders correctly 1`] = `
           Balance
         </h4>
         <div
-          class="c20"
+          class="c21"
           display="flex"
         >
           <h4
-            class="c22 c23"
+            class="c23 c24"
             color="core.black"
             font-family="RT-Alias-Grotesk"
             font-size="2"
@@ -1051,11 +1053,11 @@ exports[`WalletView it renders correctly 1`] = `
             Approx.
           </h4>
           <div
-            class="c24"
+            class="c25"
             width="2"
           />
           <h4
-            class="c25 c23"
+            class="c26 c24"
             color="core.darkgray"
             font-family="RT-Alias-Grotesk"
             font-size="2"
@@ -1066,11 +1068,11 @@ exports[`WalletView it renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="c26"
+        class="c27"
         overflow="hidden"
       >
         <h2
-          class="c27 c28"
+          class="c28 c29"
           color="card.balance.color"
           font-family="RT-Alias-Grotesk"
           font-size="6"
@@ -1081,11 +1083,11 @@ exports[`WalletView it renders correctly 1`] = `
         </h2>
       </div>
       <div
-        class="c29"
+        class="c30"
         display="flex"
       >
         <button
-          class="c30"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -1095,7 +1097,7 @@ exports[`WalletView it renders correctly 1`] = `
       </div>
     </div>
     <button
-      class="c31"
+      class="c32"
       display="flex"
       font-size="3"
       height="6"
@@ -1103,15 +1105,15 @@ exports[`WalletView it renders correctly 1`] = `
     >
       Logout
       <div
-        class="c32"
+        class="c33"
       >
         <a
           aria-label="Tooltip"
-          class="c33"
+          class="c34"
           color="core.black"
         >
           <p
-            class="c34"
+            class="c35"
             color="core.black"
             font-family="RT-Alias-Grotesk"
             font-size="2"
@@ -1121,10 +1123,10 @@ exports[`WalletView it renders correctly 1`] = `
           </p>
         </a>
         <div
-          class="c35 c36"
+          class="c36 c37"
         >
           <p
-            class="c37"
+            class="c38"
             display="block"
             font-family="RT-Alias-Grotesk"
             font-size="2"
@@ -1137,27 +1139,27 @@ exports[`WalletView it renders correctly 1`] = `
     </button>
   </div>
   <div
-    class="c38"
+    class="c39"
   >
     <div
-      class="c39"
+      class="c40"
       display="flex"
       width="100%"
     >
       <div
-        class="c40"
+        class="c41"
         width="100%"
       >
         <div
-          class="c41"
+          class="c42"
           display="flex"
         >
           <div
-            class="c42"
+            class="c43"
             display="flex"
           >
             <p
-              class="c43"
+              class="c44"
               color="core.primary"
               font-family="RT-Alias-Grotesk"
               font-size="2"
@@ -1167,7 +1169,7 @@ exports[`WalletView it renders correctly 1`] = `
             </p>
           </div>
           <button
-            class="c44"
+            class="c45"
             font-size="3"
             height="6"
             type="button"
@@ -1176,24 +1178,24 @@ exports[`WalletView it renders correctly 1`] = `
           </button>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -1225,16 +1227,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1243,7 +1245,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -1253,12 +1255,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1267,7 +1269,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1280,22 +1282,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1310,14 +1312,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1331,24 +1333,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -1380,16 +1382,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1398,7 +1400,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -1408,12 +1410,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1422,7 +1424,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1435,22 +1437,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1465,14 +1467,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1486,24 +1488,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -1535,16 +1537,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1553,7 +1555,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -1563,12 +1565,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1577,7 +1579,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1590,22 +1592,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1620,14 +1622,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1641,24 +1643,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -1690,16 +1692,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1708,7 +1710,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -1718,12 +1720,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1732,7 +1734,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1745,22 +1747,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1775,14 +1777,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1796,24 +1798,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -1845,16 +1847,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1863,7 +1865,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -1873,12 +1875,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1887,7 +1889,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1900,22 +1902,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1930,14 +1932,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -1951,24 +1953,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -2000,16 +2002,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2018,7 +2020,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -2028,12 +2030,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2042,7 +2044,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2055,22 +2057,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2085,14 +2087,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2106,24 +2108,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -2155,16 +2157,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2173,7 +2175,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -2183,12 +2185,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2197,7 +2199,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2210,22 +2212,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2240,14 +2242,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2261,24 +2263,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -2310,16 +2312,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2328,7 +2330,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -2338,12 +2340,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2352,7 +2354,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2365,22 +2367,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2395,14 +2397,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2416,24 +2418,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -2465,16 +2467,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2483,7 +2485,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -2493,12 +2495,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2507,7 +2509,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2520,22 +2522,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2550,14 +2552,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2571,24 +2573,24 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c45"
+          class="c46"
         >
           <ul
-            class="c46"
+            class="c47"
           >
             <li
-              class="c47"
+              class="c48"
               display="flex"
             >
               <ul
-                class="c48"
+                class="c49"
                 display="flex"
               >
                 <li
-                  class="c49"
+                  class="c50"
                 >
                   <svg
-                    class="c50"
+                    class="c51"
                     fill="none"
                     height="34"
                     viewBox="0 0 34 34"
@@ -2620,16 +2622,16 @@ exports[`WalletView it renders correctly 1`] = `
                 </li>
               </ul>
               <ul
-                class="c51"
+                class="c52"
                 display="flex"
               >
                 <li
-                  class="c52"
+                  class="c53"
                   overflow="hidden"
                   width="9"
                 >
                   <h4
-                    class="c53"
+                    class="c54"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2638,7 +2640,7 @@ exports[`WalletView it renders correctly 1`] = `
                     From
                   </h4>
                   <p
-                    class="c54"
+                    class="c55"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="3"
@@ -2648,12 +2650,12 @@ exports[`WalletView it renders correctly 1`] = `
                   </p>
                 </li>
                 <li
-                  class="c55"
+                  class="c56"
                   display="flex"
                   width="9"
                 >
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2662,7 +2664,7 @@ exports[`WalletView it renders correctly 1`] = `
                     2:30:30
                   </p>
                   <p
-                    class="c56"
+                    class="c57"
                     color="core.darkgray"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2675,22 +2677,22 @@ exports[`WalletView it renders correctly 1`] = `
             </li>
           </ul>
           <ul
-            class="c57"
+            class="c58"
             display="flex"
           >
             <li
               class=""
             >
               <ul
-                class="c58"
+                class="c59"
                 display="flex"
               >
                 <li
-                  class="c59"
+                  class="c60"
                   display="flex"
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2705,14 +2707,14 @@ exports[`WalletView it renders correctly 1`] = `
               class=""
             >
               <ul
-                class="c61"
+                class="c62"
                 display="flex"
               >
                 <li
                   class=""
                 >
                   <p
-                    class="c60"
+                    class="c61"
                     color="core.nearblack"
                     font-family="RT-Alias-Grotesk"
                     font-size="2"
@@ -2726,10 +2728,10 @@ exports[`WalletView it renders correctly 1`] = `
           </ul>
         </div>
         <div
-          class="c62"
+          class="c63"
         >
           <p
-            class="c63"
+            class="c64"
             color="core.primary"
             font-family="RT-Alias-Grotesk"
             font-size="2"


### PR DESCRIPTION
Hey @as-dr - I added a super ugly Signer component that illustrates how to display the Signers and distinguish the user's wallet


First, you should test this on calibration net since mainnet txs take a long time to confirm. To do that, you need to make the following changes:

- in your `next.config.js` you need to change `LOTUS_NODE_JSONRPC` to `'https://dev.node.glif.io/calibration03/lotus/rpc/v0'`
in `/utils/ledger/setLedgerProvider.js`, you need to change lines 27-29:
```
apiAddress: process.env.LOTUS_NODE_JSONRPC,
token: 'eyJhb...'
```

Same token as before in Slack.

To get started, just create your own multisig wallet. If you don't have FIL to do that (which i think you should?) you can use `f26kvyvsi5uyf2hykt4l5aigxwcmwgfsr47zul2ri` but you'll have to temporarily disable the `isAddressSigner` check:

in [this file](https://github.com/glifio/wallet/blob/primary/utils/msig/isAddressSigner.js), change it to:

```
export default async (lotus, walletAddress, signers) => true
```

You can feel free to render the Signer component outside of the AccountSummary component too. You just have to pass it those 2 props in the same way as I illustrated.