### PR TITLE
feat: export static site

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "lint": "eslint '**/*.js' '**/*.jsx'",
     "start": "next start",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "export": "next build && next export",
+    "serve": "npx serve ./out"
   },
   "dependencies": {
     "@glif/filecoin-address": "^1.1.0",


### PR DESCRIPTION
- Add npm run scripts to `export` and `serve` the static site as per https://github.com/glifio/wallet/issues/513 / #530 
- Use `serve` as it's the _hip_ [vercel flavour static server](https://github.com/vercel/serve).
- It blends! previously it did not! I did nothing but try again!

I was able to use the local static site to connect to a Ledger and view some accounts.

So all aboard the content-addressing train 🚂🔗🔐✨ ...any reason not to host glif on IPFS? I can PR a CI job to build and pin and dnslink the static site if it is acceptable.