### PR TITLE
Do not truncate address in send flow

### DIFF
--- a/components/Wallet/Send.tsx
+++ b/components/Wallet/Send.tsx
@@ -98,6 +98,7 @@ export const Send = ({ walletProviderOpts, pendingMsgContext }: SendProps) => {
         onChange={setToAddress}
         setIsValid={setIsToAddressValid}
         disabled={txState !== TxState.FillingForm}
+        truncate={false}
       />
       <InputV2.Filecoin
         label='Amount'

--- a/components/Wallet/__snapshots__/Send.test.tsx.snap
+++ b/components/Wallet/__snapshots__/Send.test.tsx.snap
@@ -549,7 +549,7 @@ exports[`Send it allows a user to send a message 1`] = `
                 step="any"
                 style="padding-right: 1em;"
                 type="text"
-                value="t1iury ... xaucza"
+                value="t1iuryu3ke2hewrcxp4ezhmr5cmfeq3wjhpxaucza"
               />
               
             </div>
@@ -1141,7 +1141,7 @@ exports[`Send snapshots after enter recipient state 1`] = `
                 step="any"
                 style="padding-right: 1em;"
                 type="text"
-                value="t1iury ... xaucza"
+                value="t1iuryu3ke2hewrcxp4ezhmr5cmfeq3wjhpxaucza"
               />
               
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "wallet",
       "version": "3.1.1",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {


### PR DESCRIPTION
This can still be improved with https://github.com/glifio/react-components/issues/503 but this is still an improvement. A user needs to be able to see the full recipient address