### PR TITLE
Feat/fip 36 suggestion

### DIFF
--- a/components/Fip/index.tsx
+++ b/components/Fip/index.tsx
@@ -1,17 +1,22 @@
 import {
+  ButtonRowCenter,
+  ButtonRowSpaced,
   ButtonV2,
   Dialog,
   InputV2,
   LoadingScreen,
+  navigate,
   ShadowBox,
   useWallet,
   useWalletProvider
 } from '@glif/react-components'
 import axios from 'axios'
+import { useRouter } from 'next/router'
 import { FormEvent, useEffect, useState } from 'react'
 import { Message } from '@glif/filecoin-message'
 import * as cbor from '@ipld/dag-cbor'
 import { Header, FIPData, FormState } from './Helpers'
+import { PAGE } from '../../constants'
 
 enum Vote {
   APPROVE = 'Approve',
@@ -22,11 +27,12 @@ enum Vote {
 const FIP_ID = 14
 
 export const Fip = () => {
-  const [vote, setVote] = useState<Vote>(Vote.REJECT)
+  const [vote, setVote] = useState<Vote | ''>('')
   const [fipDetails, setFipDetails] = useState<FIPData>(null)
   const [error, setError] = useState<Error | null>(null)
   const [formState, setFormState] = useState<FormState>(FormState.FETCHING_VOTE)
 
+  const router = useRouter()
   const wallet = useWallet()
   const { getProvider, walletError } = useWalletProvider()
 
@@ -96,13 +102,30 @@ export const Fip = () => {
                 disabled={formState > FormState.FILLING_FORM}
               />
             </ShadowBox>
-            <ButtonV2
-              green
-              type='submit'
-              disabled={formState > FormState.FILLING_FORM}
-            >
-              Vote
-            </ButtonV2>
+            {formState <= FormState.FILLING_FORM && (
+              <ButtonRowSpaced>
+                <ButtonV2 large type='button' onClick={router.back}>
+                  Back
+                </ButtonV2>
+                <ButtonV2 large green type='submit' disabled={vote === ''}>
+                  Vote
+                </ButtonV2>
+              </ButtonRowSpaced>
+            )}
+            {formState === FormState.SUCCESS && (
+              <ButtonRowCenter>
+                <ButtonV2
+                  large
+                  green
+                  type='button'
+                  onClick={() =>
+                    navigate(router, { pageUrl: PAGE.WALLET_HOME })
+                  }
+                >
+                  Done
+                </ButtonV2>
+              </ButtonRowCenter>
+            )}
           </form>
         </Dialog>
       ) : (

--- a/components/Fip/index.tsx
+++ b/components/Fip/index.tsx
@@ -74,7 +74,7 @@ export const Fip = () => {
         })
         .finally(() => setFormState(FormState.FILLING_FORM))
     }
-  }, [formState, setFormState, fipDetails, setFipDetails])
+  }, [formState, setFormState, setFipDetails])
 
   return (
     <>

--- a/pages/fip-36.tsx
+++ b/pages/fip-36.tsx
@@ -1,4 +1,8 @@
-import { navigate, OneColumn, RequireWallet } from '@glif/react-components'
+import {
+  navigate,
+  OneColumnCentered,
+  RequireWallet
+} from '@glif/react-components'
 import { useRouter } from 'next/router'
 import { useCallback } from 'react'
 import { Fip } from '../components/Fip'
@@ -14,9 +18,9 @@ export default function Fip36() {
   return (
     <WalletPageLoggedIn>
       <RequireWallet gatekeep={gatekeep}>
-        <OneColumn>
+        <OneColumnCentered>
           <Fip />
-        </OneColumn>
+        </OneColumnCentered>
       </RequireWallet>
     </WalletPageLoggedIn>
   )


### PR DESCRIPTION
The original PR looks good! The main problem is that the signing popup doesn't show for me in Metamask.

Just a few small UI suggestions:

- Centering the vote form (it's kind of a convention with these kind of forms, but just top aligning looks fine for me as well actually)
- Setting vote to a default of an empty string so that the placeholder `Select` will show. Disables the Vote button when the value is an empty string.
- I think it'd be nice to show a back button initially and have some kind of button on the final screen to go back to the wallet home, instead of just a disabled Vote button