### PR TITLE
Fix typo

### DIFF
--- a/__mocks__/@zondax/filecoin-signing-tools.js
+++ b/__mocks__/@zondax/filecoin-signing-tools.js
@@ -32,20 +32,7 @@ const serializeParams = jest
     return createHash([JSON.stringify(params), version, method].join(''))
   })
 
-const createMultisig = jest.fn().mockImplementation(
-  //eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (walletAddress, signerAddresses, value, numSigners, nonce, vest, epoch) => {
-    // normally this returns the whole message but we just use the params
-    return {
-      from: walletAddress,
-      to: 't01',
-      params: 'xxyyzzz'
-    }
-  }
-)
-
 module.exports = {
-  createMultisig,
   keyRecover,
   keyDerive,
   generateMnemonic,

--- a/components/Wallet/index.tsx
+++ b/components/Wallet/index.tsx
@@ -25,7 +25,7 @@ import { PAGE } from '../../constants'
 
 const Cards = styled.div`
   display: flex;
-  gap: var(--space-l)};
+  gap: var(--space-l);
 `
 
 export default function WalletHome() {


### PR DESCRIPTION
Found a small CSS typo and noticed we can remove the createMultisig mock as we don't use it